### PR TITLE
No area set exceptions

### DIFF
--- a/Plugin/ExceptionCatcher.php
+++ b/Plugin/ExceptionCatcher.php
@@ -67,6 +67,7 @@ class ExceptionCatcher
     )
     {
         $this->data = $data;
+        $state->setAreaCode(\Magento\Framework\App\Area::AREA_GLOBAL);
         $this->state = $state;
         $this->logger = $logger;
         $this->customerSession = $catalogSession;

--- a/Plugin/ExceptionCatcher.php
+++ b/Plugin/ExceptionCatcher.php
@@ -8,6 +8,7 @@ use Magento\Framework\App\Http;
 use Magento\Framework\App\Bootstrap;
 use JustBetter\Sentry\Helper\Data;
 use Magento\Framework\App\State;
+use Magento\Framework\App\Area;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\RavenHandler;
 use Monolog\Logger;
@@ -67,7 +68,7 @@ class ExceptionCatcher
     )
     {
         $this->data = $data;
-        $state->setAreaCode(\Magento\Framework\App\Area::AREA_GLOBAL);
+        $state->setAreaCode(Area::AREA_GLOBAL);
         $this->state = $state;
         $this->logger = $logger;
         $this->customerSession = $catalogSession;


### PR DESCRIPTION
The plugin forces session to be loaded before area is set, creates lots of exceptions in the logs.