### PR TITLE
Support for setting the environment

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -26,7 +26,8 @@ class Data extends AbstractHelper
         'domain',
         'enabled',
         'log_level',
-        'mage_mode_development'
+        'mage_mode_development',
+        'environment'
     ];
 
     /**

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -63,7 +63,7 @@ class SentryLog extends Monolog
         if ($logLevel >= (int) $config['log_level']) {
             $client = (new Raven_Client($config['domain'] ?? null));
 
-            if(!is_null($config['environment'])) {
+            if (!is_null($config['environment'])) {
                 $client->setEnvironment($config['environment']);
             }
             

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -62,6 +62,11 @@ class SentryLog extends Monolog
 
         if ($logLevel >= (int) $config['log_level']) {
             $client = (new Raven_Client($config['domain'] ?? null));
+
+            if(!is_null($config['environment'])) {
+                $client->setEnvironment($config['environment']);
+            }
+            
             $handler = new RavenHandler($client, $config['log_level'] ?? Logger::ERROR);
             $tags = $this->getTags();
             $userData = $this->getUserData();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,6 +23,10 @@
                     <label>Sentry domain</label>
                     <comment>The domain of sentry</comment>
                 </field>
+                <field id="environment" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Sentry environment</label>
+                    <comment>The environment of sentry</comment>
+                </field>
                 <field id="log_level" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Log Level</label>
                     <comment>Minimum log level to send to Sentry</comment>


### PR DESCRIPTION
Hi Just Better, we added a configuration setting for sending the environment variable. In our case this was necessary, because of acceptance environments that are running in production mode. See https://docs.sentry.io/enriching-error-data/environments/?platform=javascript