### PR TITLE
Avoiding Magento crash if logging occurs before area code setup

### DIFF
--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -10,6 +10,7 @@ use JustBetter\Sentry\Helper\Data;
 use Magento\Customer\Model\Session;
 use Monolog\Formatter\LineFormatter;
 use Magento\Framework\Logger\Monolog;
+use Magento\Framework\Exception\SessionException;
 
 class SentryLog extends Monolog
 {
@@ -91,7 +92,9 @@ class SentryLog extends Monolog
             }
 
             /// when using JS SDK you can use this for custom error page printing
-            $this->customerSession->setSentryEventId($client->getLastEventID());
+            try {
+                $this->customerSession->setSentryEventId($client->getLastEventID());
+            } catch (SessionException $e) {}
         }
     }
 
@@ -102,16 +105,18 @@ class SentryLog extends Monolog
      */
     protected function getUserData()
     {
-        if ($this->customerSession->isLoggedIn()) {
-            $customerData = $this->customerSession->getCustomer();
+        try {
+            if ($this->customerSession->isLoggedIn()) {
+                $customerData = $this->customerSession->getCustomer();
 
-            return [
-                'id' => $customerData->getEntityId(),
-                'email' => $customerData->getEmail(),
-                'website_id' => $customerData->getWebsiteId(),
-                'store_id' => $customerData->getStoreId(),
-            ];
-        }
+                return [
+                    'id' => $customerData->getEntityId(),
+                    'email' => $customerData->getEmail(),
+                    'website_id' => $customerData->getWebsiteId(),
+                    'store_id' => $customerData->getStoreId(),
+                ];
+            }
+        } catch (SessionException $e) {}
 
         return [];
     }


### PR DESCRIPTION
**Summary**

If a Sentry event occured before the Magento Area Code is set, Magento will crash because Sentry try to use session data, which is not (and can't be) initialized at this point.

This occur at least if Magento Maintenance mode is enabled
```
bin/magento maintenance:enable
```

**Result**

In my use case (Magento Maintenance mode as said before), the maintenance message now displays correctly.
Please note that the Magento Maintenance mode is considered as an ERROR event and will be sent to Sentry, which should imo not occur, but it doesn't seem Magento send a specific Exception for this case, and makes it difficult to identify.

**Another way**

This PR simply does a try/catch using SessionException to prevent crashing.
Another way to do this is to detect if the session is initialized before trying to get or set data to session.
This test is done by `\Magento\Framework\Session\SessionManager::isSessionExists()`, but this method can't be used in this case because `SessionManager` will try to create a session during its instanciation and will raise the same problem with the area code.
This must be done using `isSessionExists()` implementation, by testing `session_status() !== PHP_SESSION_NONE`.
This is imo a bit overkilled considering this problem, that's why I've taken a try/catch solution.

Please also note that trying to get areaCode will also lead to using a try/catch: the only way to access the area code within `\Magento\Framework\App\State` is using `getAreaCode()`, which throws a `LocalizedException` if its value isn't set.
