### PR TITLE
Clarify purpose of two config fields

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -25,11 +25,12 @@
                 </field>
                 <field id="domain" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Sentry domain</label>
-                    <comment>The domain of sentry</comment>
+                    <comment><![CDATA[The domain of sentry (Data Source Name). Sentry will provide this value once you create a project. Will be a string like <pre><code>https://7a83f8de8fe04f5194742a7bbd401ed8@sentry.io/1734931</code></pre>]]></comment>
                 </field>
                 <field id="environment" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Sentry environment</label>
-                    <comment>The environment of sentry</comment>
+                    <comment><![CDATA[The environment to send to Sentry (optional). Can be any arbitrary string (e.g., "staging" or "production"). Refer to the <a href="https://docs.sentry.io/enriching-error-data/environments/?platform=php
+" target="_blank">Sentry documentation</a> for details.]]></comment>
                 </field>
                 <field id="script_tag_placement" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Script tag location</label>


### PR DESCRIPTION
**Summary**

I found the "Sentry domain" and "Sentry environment" config fields non-intuitive, and I had to figure out what they meant. This PR adds more explanatory comments to the config fields. Note: the example DSN is fictitious… but I thought it was useful to include in the comment since I initially thought I should enter only the domain without the trailing numbers.

**Result**

The updated config fields look like this:

![ Magento Admin 2019-08-19 11-04-28](https://user-images.githubusercontent.com/129031/63280958-626e4e80-c271-11e9-9424-84551a229ae4.jpg)
