### PR TITLE
Remove shell injection vulnerability

### DIFF
--- a/Controller/Adminhtml/Test/Sentry.php
+++ b/Controller/Adminhtml/Test/Sentry.php
@@ -81,7 +81,7 @@ class Sentry extends Action
         if ($sentryDomain && is_dir($composerBin)) {
             try {
                 $result['status']  = true;
-                $result['content'] = nl2br(shell_exec($composerBin.'sentry test '.$sentryDomain.' -v'));
+                $result['content'] = nl2br(shell_exec($composerBin . 'sentry test ' . escapeshellarg($sentryDomain) . ' -v'));
             } catch (\Exception $e) {
                 $result['content'] = $e->getMessage();
                 $this->logger->critical($e);


### PR DESCRIPTION
The URL parameter `domainSentry` was being used without being sanitised as a command line argument by `shell_exec()`. This change adds shell argument escaping to this value before passing to `shell_exec()`.