### PR TITLE
Fix #23: Verifying Magento is installed before accessing Sentry config

### DIFF
--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -2,11 +2,12 @@
 
 namespace JustBetter\Sentry\Plugin;
 
-use Magento\Framework\App\Area;
-use Magento\Framework\App\State;
 use JustBetter\Sentry\Helper\Data;
-use Magento\Framework\Logger\Monolog;
 use JustBetter\Sentry\Model\SentryLog;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\State;
+use Magento\Framework\Logger\Monolog;
 
 class MonologPlugin extends Monolog
 {
@@ -21,12 +22,24 @@ class MonologPlugin extends Monolog
     protected $sentryLog;
 
     /**
-    * {@inheritdoc}
-    */
-    public function __construct($name, Data\Proxy $data, SentryLog\Proxy $sentryLog, array $handlers = [], array $processors = [])
-    {
+     * @var DeploymentConfig
+     */
+    protected $deploymentConfig;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        $name,
+        Data\Proxy $data,
+        SentryLog\Proxy $sentryLog,
+        DeploymentConfig\Proxy $deploymentConfig,
+        array $handlers = [],
+        array $processors = []
+    ) {
         $this->sentryHelper = $data;
         $this->sentryLog = $sentryLog;
+        $this->deploymentConfig = $deploymentConfig;
 
         parent::__construct($name, $handlers, $processors);
     }
@@ -41,7 +54,7 @@ class MonologPlugin extends Monolog
      */
     public function addRecord($level, $message, array $context = [])
     {
-        if ($this->sentryHelper->isActive()) {
+        if ($this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive()) {
             $this->sentryLog->send($message, $level, $this, $context);
         }
 


### PR DESCRIPTION
This Pull Requests fixes issue #23.
I also reordered imports.

My solution matches [Magento 2 Framework Bootstrap](https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/App/Bootstrap.php#L359) installation test.

This test can not be easily integrated in the helper, as the helper cannot be instancied without an installed Magento.