### PR TITLE
Use the Magento Deployment Configuration to save the configuration values

### DIFF
--- a/Block/Adminhtml/System/Config/DeploymentConfigInfo.php
+++ b/Block/Adminhtml/System/Config/DeploymentConfigInfo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace JustBetter\Sentry\Block\Adminhtml\System\Config;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class DeploymentConfigInfo extends Field
+{
+    /**
+     * @var string
+     */
+    protected $_template = 'system/config/deployment-config-info.phtml';
+
+    public function render(AbstractElement $element)
+    {
+        return $this->_toHtml();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ This Magento 2 module integrates the [Sentry sdk](https://github.com/getsentry/s
 - `bin/magento setup:static-content:deploy`
 
 ## Configuration
-- Options for the module are defined in the backend under Stores > Configuration > JustBetter > Sentry configuration
+This module uses the [Magento Deployment Configuration](https://devdocs.magento.com/guides/v2.3/config-guide/config/config-php.html) for most it's configuration. This means that you need to add this array to your `app/etc/env.php`:
+
+```
+'sentry' => [
+    'domain' => 'example.com',
+    'environment' => null,
+    'log_level' => \Monolog\Logger::WARNING,
+    'isOverwriteProductionMode' => false,
+]
+```
+
+Next to that there are some configuration options under Stores > Configuration > JustBetter > Sentry.
 
 ## Optional error page configuration
 - Optional you can configure custom error pages in pub/errors. You can use the sentry feedback form and insert here the sentry log ID. The Sentry Log Id is captured in de customer session and can be retrieved in `processor.php`. Soon I'll integrate this in the module.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -11,40 +11,22 @@
             <resource>JustBetter_Sentry::configuration</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Sentry general config</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Sentry enabled</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <field id="deployment_config_info" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Deployment config info</label>
+                    <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\DeploymentConfigInfo</frontend_model>
                 </field>
                 <field id="enable_script_tag" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enable Sentry script tag</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="mage_mode_development" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Send errors in development mode</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                </field>
-                <field id="domain" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Sentry domain</label>
-                    <comment><![CDATA[The domain of sentry (Data Source Name). Sentry will provide this value once you create a project. Will be a string like <pre><code>https://7a83f8de8fe04f5194742a7bbd401ed8@sentry.io/1734931</code></pre>]]></comment>
-                </field>
-                <field id="environment" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Sentry environment</label>
-                    <comment><![CDATA[The environment to send to Sentry (optional). Can be any arbitrary string (e.g., "staging" or "production"). Refer to the <a href="https://docs.sentry.io/enriching-error-data/environments/?platform=php
-" target="_blank">Sentry documentation</a> for details.]]></comment>
-                </field>
-                <field id="script_tag_placement" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="script_tag_placement" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Script tag location</label>
                     <source_model>JustBetter\Sentry\Model\Config\Source\ScriptTagPlacement</source_model>
                     <depends>
                         <field id="enable_script_tag">1</field>
                     </depends>
                 </field>
-                <field id="log_level" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Log Level</label>
-                    <comment>Minimum log level to send to Sentry</comment>
-                    <source_model>JustBetter\Sentry\Model\Config\Source\LogLevel</source_model>
-                </field>
-                <field id="sent" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="sent" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <button_label>Send sentry test event</button_label>
                     <button_url>justbetter_sentry/test/sentry</button_url>
                     <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\Button</frontend_model>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,0 +1,2 @@
+How to configure Sentry?,How to configure Sentry?
+"This module uses the <a href="https://devdocs.magento.com/guides/v2.3/config-guide/config/config-php.html" target="_BLANK">Magento Deployment Configuration</a> for most it's configuration. This means that you need to add this array to your `app/etc/env.php`:","This module uses the <a href="https://devdocs.magento.com/guides/v2.3/config-guide/config/config-php.html" target="_BLANK">Magento Deployment Configuration</a> for most it's configuration. This means that you need to add this array to your `app/etc/env.php`:"

--- a/view/adminhtml/templates/system/config/deployment-config-info.phtml
+++ b/view/adminhtml/templates/system/config/deployment-config-info.phtml
@@ -1,0 +1,15 @@
+<td></td>
+<td>
+    <h2><?php echo __('How to configure Sentry?'); ?></h2>
+    <p><?php echo __('This module uses the <a href="https://devdocs.magento.com/guides/v2.3/config-guide/config/config-php.html" target="_BLANK">Magento Deployment Configuration</a> for most it\'s configuration. This means that you need to add this array to your `app/etc/env.php`:'); ?></p>
+
+    <pre>
+<?php echo htmlentities("
+'sentry' => [
+    'domain' => 'example.com',
+    'environment' => null,
+    'log_level' => \Monolog\Logger::WARNING,
+    'isOverwriteProductionMode' => false,
+]"); ?>
+    </pre>
+</td>


### PR DESCRIPTION
Hi,

We had the same problem as described in #28, saving configuration was slow. I took the suggestion in the ticket and moved the required configuration to the deployment configuration. I have added an info block in the configuration, and updated the readme. If this gets merged i advice to tag it as a major version as this is backward incompatible.