### PR TITLE
Fixes #32 - backend test button

### DIFF
--- a/Controller/Adminhtml/Test/Sentry.php
+++ b/Controller/Adminhtml/Test/Sentry.php
@@ -88,7 +88,7 @@ class Sentry extends Action
             try {
                 $this->monologPlugin->addAlert('TEST message from Magento 2', []);
                 $result['status']  = true;
-                $result['content'] = __('Check sentry.io which should hold an error');
+                $result['content'] = __('Check sentry.io which should hold an alert');
             } catch (\Exception $e) {
                 $result['content'] = $e->getMessage();
                 $this->logger->critical($e);

--- a/Controller/Adminhtml/Test/Sentry.php
+++ b/Controller/Adminhtml/Test/Sentry.php
@@ -2,12 +2,14 @@
 
 namespace JustBetter\Sentry\Controller\Adminhtml\Test;
 
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\SentryLog;
+use JustBetter\Sentry\Plugin\MonologPlugin;
+use Magento\Framework\Serialize\Serializer\Json;
 use Psr\Log\LoggerInterface;
 use Magento\Backend\App\Action;
-use Magento\Framework\Json\Helper\Data;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\View\Result\PageFactory;
-use Magento\Framework\Filesystem\DirectoryList;
 
 /**
  * Class Sentry
@@ -24,45 +26,51 @@ class Sentry extends Action
     const ADMIN_RESOURCE = 'JustBetter_Sentry::sentry';
 
     /**
-     * @var \Magento\Framework\View\Result\PageFactory
+     * @var PageFactory
      */
     protected $resultPageFactory;
 
     /**
-     * @var \Magento\Framework\Json\Helper\Data
-     */
-    protected $jsonHelper;
-
-    /**
-     * @var \Psr\Log\LoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * @var DirectoryList
+     * @var Json
      */
-    protected $directoryList;
+    private $jsonSerializer;
+    /**
+     * @var Data
+     */
+    private $helperSentry;
+    /**
+     * @var JustBetter\Sentry\Model\SentryLog|SentryLog
+     */
+    private $monologPlugin;
 
     /**
      * Sentry constructor.
      *
-     * @param \Magento\Backend\App\Action\Context        $context
-     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
-     * @param \Magento\Framework\Json\Helper\Data        $jsonHelper
-     * @param \Psr\Log\LoggerInterface                   $logger
-     * @param DirectoryList                              $directoryList
+     * @param Context $context
+     * @param PageFactory $resultPageFactory
+     * @param Json $jsonSerializer
+     * @param LoggerInterface $logger
+     * @param Data $helperSentry
+     * @param MonologPlugin $monologPlugin
      */
     public function __construct(
         Context $context,
         PageFactory $resultPageFactory,
-        Data $jsonHelper,
+        Json $jsonSerializer,
         LoggerInterface $logger,
-        DirectoryList $directoryList
+        Data $helperSentry,
+        MonologPlugin $monologPlugin
     ) {
         $this->resultPageFactory = $resultPageFactory;
-        $this->jsonHelper        = $jsonHelper;
+        $this->jsonSerializer    = $jsonSerializer;
         $this->logger            = $logger;
-        $this->directoryList     = $directoryList;
+        $this->helperSentry      = $helperSentry;
+        $this->monologPlugin     = $monologPlugin;
 
         parent::__construct($context);
     }
@@ -75,26 +83,22 @@ class Sentry extends Action
     public function execute()
     {
         $result = ['status' => false];
-        $sentryDomain = $this->getRequest()->getParam('domainSentry');
-        $composerBin = $this->directoryList->getRoot() .'/vendor/bin/';
 
-        if ($sentryDomain && is_dir($composerBin)) {
+        if ($this->helperSentry->isActive()) {
             try {
+                $this->monologPlugin->addAlert('TEST message from Magento 2', []);
                 $result['status']  = true;
-                $result['content'] = nl2br(shell_exec(
-                    $composerBin . 'sentry test ' . escapeshellarg($sentryDomain) . ' -v'
-                ));
+                $result['content'] = __('Check sentry.io which should hold an error');
             } catch (\Exception $e) {
                 $result['content'] = $e->getMessage();
                 $this->logger->critical($e);
             }
         } else {
-            $result['content'] = __('Sentry Domain not filled or composer bin not found!');
+            $result['content'] = __('Sentry Domain not filled!');
         }
 
-
         return $this->getResponse()->representJson(
-            $this->jsonHelper->jsonEncode($result)
+            $this->jsonSerializer->serialize($result)
         );
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'domain' => 'example.com',
     'environment' => null,
     'log_level' => \Monolog\Logger::WARNING,
-    'isOverwriteProductionMode' => false,
+    'mage_mode_development' => false,
 ]
 ```
 

--- a/view/adminhtml/templates/system/config/button.phtml
+++ b/view/adminhtml/templates/system/config/button.phtml
@@ -8,7 +8,7 @@
 </div>
 <script type="text/x-magento-init">
     {
-        "#sentry_general_domain": {
+        "#<?php echo $block->getHtmlId() ?>": {
             "validation": {},
             "justbetter/testsentry": {
                 "ajaxUrl": "<?php /* @escapeNotVerified */ echo $block->getButtonUrl() ?>"

--- a/view/adminhtml/templates/system/config/deployment-config-info.phtml
+++ b/view/adminhtml/templates/system/config/deployment-config-info.phtml
@@ -9,7 +9,7 @@
     'domain' => 'example.com',
     'environment' => null,
     'log_level' => \Monolog\Logger::WARNING,
-    'isOverwriteProductionMode' => false,
+    'mage_mode_development' => false,
 ]"); ?>
     </pre>
 </td>

--- a/view/adminhtml/web/js/testsentry.js
+++ b/view/adminhtml/web/js/testsentry.js
@@ -16,11 +16,9 @@ define([
 			var self = this;
 			self.element.addClass('required-entry');
 
-			$(this.options.testSentry).click(function (e) {
+			self.element.click(function (e) {
 				e.preventDefault();
-				if (self.element.val()) {
-					self._ajaxSubmit();
-				}
+				self._ajaxSubmit();
 			});
 		},
 
@@ -28,14 +26,13 @@ define([
 			$.ajax({
 				url: this.options.ajaxUrl,
 				data: {
-					domainSentry: $(this.options.domainSentry).val()
 				},
 				dataType: 'json',
 				showLoader: true,
 				success: function (result) {
 					alert({
 						title: result.status ? $t('Success') : $t('Error'),
-						content: result.content
+						content: result.content ? result.content : result.message
 					});
 				}
 			});

--- a/view/adminhtml/web/js/testsentry.js
+++ b/view/adminhtml/web/js/testsentry.js
@@ -23,10 +23,8 @@ define([
 		},
 
 		_ajaxSubmit: function () {
-			$.ajax({
+			$.get({
 				url: this.options.ajaxUrl,
-				data: {
-				},
 				dataType: 'json',
 				showLoader: true,
 				success: function (result) {


### PR DESCRIPTION
Sentry module is also updated since `2.0.0` which removes the beloved `vendor/bin/sentry` command. I've updated the backend test code to just add an Alert and has a check that Sentry is active.

**Result**
![image](https://user-images.githubusercontent.com/1163348/69286233-9e0b1280-0bea-11ea-90c4-f421b54dcaa4.png)

**Backend alert**
![image](https://user-images.githubusercontent.com/1163348/69286265-b1b67900-0bea-11ea-88e1-6b0189491cc9.png)
