### PR TITLE
For sentry tag to show on FE block must be active, enabled and allowe…

### DIFF
--- a/Block/SentryScript.php
+++ b/Block/SentryScript.php
@@ -31,9 +31,9 @@ class SentryScript extends Template
      */
     public function canUseScriptTag($blockName)
     {
-        return  !$this->dataHelper->isActive() ||
-                !$this->dataHelper->useScriptTag() ||
-                !$this->dataHelper->showScriptTagInThisBlock($blockName);
+        return $this->dataHelper->isActive() &&
+               $this->dataHelper->useScriptTag() &&
+               $this->dataHelper->showScriptTagInThisBlock($blockName);
     }
 
     /**


### PR DESCRIPTION
…d in this position

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Currently only one of `isActive()`, `useScriptTag()` or`showScriptTagInThisBlock($blockName)` need to return true for the script tag on the frontend to show when they all should.

Resolves #47 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

With DB config (from older version):
```
sentry/general/enabled	1
sentry/general/mage_mode_development	0
sentry/general/domain	https://xxx@sentry.io/xxx
sentry/general/environment	staging	2020-01-02
sentry/general/log_level	500
```
and app/etc/env.php:
```
    'sentry' => [
        'dsn' => 'https://xxx@sentry.io/xxx',
        'environment' => 'staging',
        'log_level' => 500,
        'mage_mode_development' => false,
        'enable_script_tag' => false
    ],
```

Two blocks with the below contents were output in the head and footer of the site:

```
<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise" crossorigin></script>
<script src="https://browser.sentry-cdn.com/4.5.3/bundle.min.js" crossorigin></script>
<script>Sentry.init({ dsn: 'https://xxx@sentry.io/xxx' });</script>
```

With the modification in the PR, no blocks are output.

Setting sentry/general/enable_script_tag to 1 in core_config_data will show it.


