### PR TITLE
Add option to enable or disable Php error tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/Controller/Adminhtml/Test/Sentry.php
+++ b/Controller/Adminhtml/Test/Sentry.php
@@ -88,9 +88,13 @@ class Sentry extends Action
 
         if ($activeWithReason['active']) {
             try {
-                $this->monologPlugin->addAlert('TEST message from Magento 2', []);
-                $result['status'] = true;
-                $result['content'] = __('Check sentry.io which should hold an alert');
+                if ($this->helperSentry->isPhpTrackingEnabled()) {
+                    $this->monologPlugin->addAlert('TEST message from Magento 2', []);
+                    $result['status'] = true;
+                    $result['content'] = __('Check sentry.io which should hold an alert');
+                } else {
+                    $result['content'] = __('Php error tracking must be enabled for testing');
+                }
             } catch (\Exception $e) {
                 $result['content'] = $e->getMessage();
                 $this->logger->critical($e);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -203,6 +203,14 @@ class Data extends AbstractHelper
     /**
      * @return bool
      */
+    public function isPhpTrackingEnabled()
+    {
+        return $this->scopeConfig->isSetFlag(static::XML_PATH_SRS.'enable_php_tracking');
+    }
+
+    /**
+     * @return bool
+     */
     public function useScriptTag()
     {
         return $this->scopeConfig->isSetFlag(static::XML_PATH_SRS.'enable_script_tag');

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -39,7 +39,7 @@ class GlobalExceptionCatcher
 
     public function aroundLaunch(AppInterface $subject, callable $proceed)
     {
-        if (!$this->sentryHelper->isActive()) {
+        if ((!$this->sentryHelper->isActive()) || (!$this->sentryHelper->isPhpTrackingEnabled())) {
             return $proceed();
         }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -15,8 +15,12 @@
                     <label>Deployment config info</label>
                     <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\DeploymentConfigInfo</frontend_model>
                 </field>
+                <field id="enable_php_tracking" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Php Tracking</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="enable_script_tag" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Enable Sentry script tag</label>
+                    <label>Enable Javascript Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="script_tag_placement" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,11 @@
     <default>
         <sentry>
             <general>
+                <enable_php_tracking>0</enable_php_tracking>
+                <enable_script_tag>0</enable_script_tag>
                 <script_tag_placement>before.body.end</script_tag_placement>
+                <use_logrocket>0</use_logrocket>
+                <logrocket_identify>0</logrocket_identify>
             </general>
         </sentry>
     </default>


### PR DESCRIPTION
**Summary**
This Pull Request adds functionality to [enable or disable Php Error Tracking by providing an option in Magento Admin UI](https://github.com/justbetter/magento2-sentry/issues/58#issue-683647066).

**Result**
![Peek 2020-08-24 20-44](https://user-images.githubusercontent.com/5053687/91062949-f7f1aa80-e64a-11ea-8207-2ea7a49b5379.gif)