### PR TITLE
Adding environment to js integration

### DIFF
--- a/Block/SentryScript.php
+++ b/Block/SentryScript.php
@@ -74,6 +74,16 @@ class SentryScript extends Template
     }
 
     /**
+     * Get the current environment of Sentry.
+     *
+     * @return mixed
+     */
+    public function getEnvironment()
+    {
+        return $this->dataHelper->getEnvironment();
+    }
+
+    /**
      * If LogRocket should be used.
      *
      * @return bool

--- a/view/frontend/templates/script/sentry.phtml
+++ b/view/frontend/templates/script/sentry.phtml
@@ -13,8 +13,9 @@ if (!$block->canUseScriptTag($block->getNameInLayout())) {
 </script>
 <script>
     Sentry.init({
-        dsn: '<?= $block->escapeUrl(trim($block->getDSN())); ?>',
-        release: '<?= $block->escapeHtml(trim($block->getVersion())); ?>'
+        dsn: '<?= $block->escapeUrl(trim($block->getDSN())) ?>',
+        release: '<?= $block->escapeHtml(trim($block->getVersion())) ?>',
+        environment: '<?= $block->escapeHtml(trim($block->getEnvironment())) ?>',
     });
 </script>
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
As mentioned in #61 the JS integration does not provide the environment. I also confirmed the problem. This is because the environment is not provided to the Sentry init in the script tag. 

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Adding the environment to the Sentry.init call shows it in Sentry.
<img width="1320" alt="Screenshot 2020-11-28 at 17 00 14" src="https://user-images.githubusercontent.com/32356549/100519934-5757dd00-319b-11eb-932f-09f232202bcd.png">


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
