### PR TITLE
Use isset to check for custom_tags in context

### DIFF
--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -69,7 +69,7 @@ class SentryLog extends Monolog
             return;
         }
 
-        if (true === \array_key_exists('custom_tags', $context)) {
+        if (true === isset($context['custom_tags']) && false === empty($context['custom_tags'])) {
             $customTags = $context['custom_tags'];
             unset($context['custom_tags']);
         }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
In #68 it was reported that under specific circumstances, if the context is an array, the newly added functionality for adding custom tags will cause an error. 
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
Changing the current check from array_key_exists to isset and additionally check for empty custom_tags as isset only fails if the key returns null.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
