### PR TITLE
Update addRecord function for Monolog 2.7+

### DIFF
--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -6,6 +6,7 @@ use JustBetter\Sentry\Helper\Data;
 use JustBetter\Sentry\Model\SentryLog;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Logger\Monolog;
+use Monolog\DateTimeImmutable;
 
 class MonologPlugin extends Monolog
 {
@@ -51,12 +52,16 @@ class MonologPlugin extends Monolog
      *
      * @return bool Whether the record has been processed
      */
-    public function addRecord(int $level, string $message, array $context = []): bool
-    {
+    public function addRecord(
+        int $level,
+        string $message,
+        array $context = [],
+        DateTimeImmutable $datetime = null
+    ): bool {
         if ($this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive()) {
             $this->sentryLog->send($message, $level, $context);
         }
 
-        return parent::addRecord($level, $message, $context);
+        return parent::addRecord($level, $message, $context, $datetime);
     }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
Since the release of Monolog 3.1 and 2.7 the parameter `$datetime` was added to the `addRecord` function
See:
- https://github.com/Seldaek/monolog/releases/tag/3.1.0
- https://github.com/Seldaek/monolog/releases/tag/2.7.0

Without the change of this PR `bin/magento setup:di:compile` will fail:
`PHP Fatal error:  Declaration of JustBetter\Sentry\Plugin\MonologPlugin::addRecord(int $level, string $message, array $context = []): bool must be compatible with Monolog\Logger::addRecord(int $level, string $message, array $context = [], ?Monolog\DateTimeImmutable $datetime = null): bool in /var/www/html/vendor/justbetter/magento2-sentry/Plugin/MonologPlugin.php on line 54`

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
Command runs without errors.