### PR TITLE
Feat performance

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -236,6 +236,14 @@ class Data extends AbstractHelper
     /**
      * @return bool
      */
+    public function isPerformanceTrackingEnabled()
+    {
+        return $this->scopeConfig->isSetFlag(static::XML_PATH_SRS.'enable_performance_tracking');
+    }
+
+    /**
+     * @return bool
+     */
     public function useScriptTag()
     {
         return $this->scopeConfig->isSetFlag(static::XML_PATH_SRS.'enable_script_tag');

--- a/Model/SentryPerformance.php
+++ b/Model/SentryPerformance.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model;
+
+// phpcs:disable Magento2.Functions.DiscouragedFunction
+
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
+use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
+
+class SentryPerformance
+{
+    private $transaction;
+
+    public function startTransaction(Http $request)
+    {
+        $requestStartTime = $request->getServer('REQUEST_TIME_FLOAT', microtime(true));
+
+        $context = TransactionContext::fromHeaders(
+            $request->getHeader('sentry-trace') ?: '',
+            $request->getHeader('baggage') ?: ''
+        );
+
+        $requestPath = '/' . ltrim($request->getRequestUri(), '/');
+        
+        $context->setOp('http.server');
+        $context->setName($requestPath);
+        $context->setSource(TransactionSource::url());
+        $context->setStartTimestamp($requestStartTime);
+
+        $context->setData([
+            'url' => $requestPath,
+            'method' => strtoupper($request->getMethod()),
+        ]);
+
+        // Start the transaction
+        $transaction = \Sentry\startTransaction($context);
+
+        // If this transaction is not sampled, don't set it either and stop doing work from this point on
+        if (!$transaction->getSampled()) {
+            return;
+        }
+
+        $this->transaction = $transaction;
+
+        // Set the current transaction as the current span so we can retrieve it later
+        \Sentry\SentrySdk::getCurrentHub()->setSpan($transaction);
+    }
+
+    public function finishTransaction()
+    {
+        if ($this->transaction) {
+            // Finish the transaction, this submits the transaction and it's span to Sentry
+            $this->transaction->finish();
+
+            $this->transaction = null;
+        }
+    }
+}

--- a/Model/SentryPerformance.php
+++ b/Model/SentryPerformance.php
@@ -25,7 +25,7 @@ class SentryPerformance
         );
 
         $requestPath = '/' . ltrim($request->getRequestUri(), '/');
-        
+
         $context->setOp('http.server');
         $context->setName($requestPath);
         $context->setSource(TransactionSource::url());

--- a/Observer/ControllerActionPostdispatchObserver.php
+++ b/Observer/ControllerActionPostdispatchObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JustBetter\Sentry\Observer;
+
+use JustBetter\Sentry\Model\SentryPerformance;
+use Magento\Framework\App\RequestInterface;
+use  \Magento\Framework\App\Response\Http;
+use Magento\Framework\Event\ObserverInterface;
+
+class ControllerActionPostdispatchObserver implements ObserverInterface
+{
+    /** @var SentryPerformance */
+    private $sentryPerformance;
+
+    /** @var Http  */
+    private $response;
+
+    public function __construct(SentryPerformance $sentryPerformance, Http $response)
+    {
+        $this->sentryPerformance = $sentryPerformance;
+        $this->response = $response;
+    }
+
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $this->sentryPerformance->finishTransaction($this->response);
+    }
+}

--- a/Observer/ControllerActionPredispatchObserver.php
+++ b/Observer/ControllerActionPredispatchObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace JustBetter\Sentry\Observer;
+
+use JustBetter\Sentry\Model\SentryPerformance;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Event\ObserverInterface;
+
+class ControllerActionPredispatchObserver implements ObserverInterface
+{
+    /** @var SentryPerformance */
+    private $sentryPerformance;
+
+    /** @var Http  */
+    private $request;
+
+    public function __construct(SentryPerformance $sentryPerformance, Http $request) {
+        $this->sentryPerformance = $sentryPerformance;
+        $this->request = $request;
+    }
+
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $this->sentryPerformance->startTransaction($this->request);
+    }
+}

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -68,7 +68,7 @@ class GlobalExceptionCatcher
             $config->setEnvironment($environment);
         }
 
-        if ($this->sentryHelper->isTracingEnabled()) {
+        if ($this->sentryHelper->isTracingEnabled() && $this->sentryHelper->isPerformanceTrackingEnabled()) {
             $config->setTracesSampleRate($this->sentryHelper->getTracingSampleRate());
         }
 

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -68,6 +68,10 @@ class GlobalExceptionCatcher
             $config->setEnvironment($environment);
         }
 
+        if ($this->sentryHelper->isTracingEnabled()) {
+            $config->setTracesSampleRate($this->sentryHelper->getTracingSampleRate());
+        }
+
         $this->eventManager->dispatch('sentry_before_init', [
             'config' => $config,
         ]);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,6 +19,10 @@
                     <label>Enable PHP Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_performance_tracking" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Performance Tracking</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="enable_script_tag" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enable Javascript Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,6 +4,7 @@
         <sentry>
             <general>
                 <enable_php_tracking>1</enable_php_tracking>
+                <enable_performance_tracking>0</enable_performance_tracking>
                 <enable_script_tag>0</enable_script_tag>
                 <script_tag_placement>before.body.end</script_tag_placement>
                 <use_logrocket>0</use_logrocket>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="controller_action_predispatch">
+        <observer name="SentryPredispatch" instance="JustBetter\Sentry\Observer\ControllerActionPredispatchObserver" />
+    </event>
+    <event name="controller_action_postdispatch">
+        <observer name="SentryPostdispatch" instance="JustBetter\Sentry\Observer\ControllerActionPostdispatchObserver" />
+    </event>
+</config>


### PR DESCRIPTION
This adds initial performance tracking by sending (server side) transactions. Could be used to add long-running queries or other events perhaps. Needs to set a sample rate + enable it in the backend.

(Not very much experience with this, but it does seem to record transactions).