### PR TITLE
Fix PHP 8.2 deprecation errors

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,6 +4,7 @@ namespace JustBetter\Sentry\Helper;
 
 use JustBetter\Sentry\Block\SentryScript;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
@@ -23,6 +24,31 @@ class Data extends AbstractHelper
     protected $storeManager;
 
     /**
+     * @var State
+     */
+    protected $appState;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var ProductMetaDataInterface
+     */
+    protected $productMetadataInterface;
+
+    /**
+     * @var DeploymentConfig
+     */
+    protected $deploymentConfig;
+
+    /**
+     * @var array
+     */
+    protected $config = [];
+
+    /**
      * @var array
      */
     protected $configKeys = [
@@ -37,16 +63,6 @@ class Data extends AbstractHelper
         'tracing_enabled',
         'tracing_sample_rate',
     ];
-
-    /**
-     * @var array
-     */
-    protected $config = [];
-
-    /**
-     * @var State
-     */
-    protected $appState;
 
     /**
      * Data constructor.


### PR DESCRIPTION
Fixes these:

```
Deprecated Functionality: Creation of dynamic property JustBetter\Sentry\Helper\Data::$productMetadataInterface is deprecated in vendor/justbetter/magento2-sentry/Helper/Data.php on line 68

  Deprecated Functionality: Creation of dynamic property JustBetter\Sentry\Helper\Data::$deploymentConfig is deprecated in vendor/justbetter/magento2-sentry/Helper/Data.php on line 73  
```

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
