### PR TITLE
check if Sentry is defined, script may be blocked by adblockers

### DIFF
--- a/view/frontend/templates/script/sentry.phtml
+++ b/view/frontend/templates/script/sentry.phtml
@@ -28,6 +28,7 @@ $remoteFile = sprintf(
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise" crossorigin></script>
 <script src="<?= /** @noEscape */$remoteFile ?>" crossorigin="anonymous"></script>
 <script>
+if (typeof Sentry !== 'undefined') {
     Sentry.init({
         dsn: '<?= $block->escapeUrl(trim($block->getDSN())) ?>',
         release: '<?= $block->escapeHtml(trim($block->getVersion())) ?>',
@@ -80,6 +81,7 @@ $remoteFile = sprintf(
         }
     <?php endif; ?>
     });
+}
 </script>
 
 <?php if ($block->useLogRocket()): ?>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Checks for variable existence, Sentry may not be defined. In my case it was blocked by an adblocker.

**Result**

Sentry Code is only executed if Sentry is defined