### PR TITLE
Feature: Allow to add configuration per store (Multiple DSN...)

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -210,7 +210,7 @@ class Data extends AbstractHelper
     {
         $reasons = [];
         $emptyConfig = empty($this->config[$this->getStoreId()]);
-        $configEnabled = array_key_exists('enabled', $this->config[$this->getStoreId()]) && $this->config[$this->getStoreId()]['enabled'];
+        $configEnabled = isset($this->config[$this->getStoreId()]['enabled']) && $this->config[$this->getStoreId()]['enabled'];
         $dsnNotEmpty = $this->getDSN();
         $productionMode = ($this->isProductionMode() || $this->isOverwriteProductionMode());
 
@@ -251,7 +251,7 @@ class Data extends AbstractHelper
      */
     public function isOverwriteProductionMode(): bool
     {
-        return array_key_exists('mage_mode_development', $this->config[$this->getStoreId()]) && $this->config[$this->getStoreId()]['mage_mode_development'];
+        return isset($this->config[$this->getStoreId()]['mage_mode_development']) && $this->config[$this->getStoreId()]['mage_mode_development'];
     }
 
     /**
@@ -345,7 +345,7 @@ class Data extends AbstractHelper
     public function useLogrocket(): bool
     {
         return $this->scopeConfig->isSetFlag(static::XML_PATH_SRS.'use_logrocket') &&
-            array_key_exists('logrocket_key', $this->config[$this->getStoreId()]) &&
+            isset($this->config[$this->getStoreId()]['logrocket_key']) &&
             $this->getLogrocketKey() !== null;
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -184,7 +184,7 @@ class Data extends AbstractHelper
         try {
             $this->config[$this->getStoreId()]['enabled'] = $this->scopeConfig->getValue('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)
                 ?? $this->deploymentConfig->get('sentry') !== null;
-        } catch (TableNotFoundException | FileSystemException | \Magento\Framework\Exception\RuntimeException $e) {
+        } catch (TableNotFoundException | FileSystemException | RuntimeException $e) {
             $this->config[$this->getStoreId()]['enabled'] = null;
         }
 
@@ -192,7 +192,7 @@ class Data extends AbstractHelper
             try {
                 $this->config[$this->getStoreId()][$value] = $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
                     ?? $this->deploymentConfig->get('sentry/'.$value);
-            } catch (TableNotFoundException | FileSystemException | \Magento\Framework\Exception\RuntimeException $e) {
+            } catch (TableNotFoundException | FileSystemException | RuntimeException $e) {
                 $this->config[$this->getStoreId()][$value] = null;
             }
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,7 +17,7 @@ use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use RuntimeException;
+use Magento\Framework\Exception\RuntimeException;
 use Throwable;
 
 class Data extends AbstractHelper
@@ -172,8 +172,6 @@ class Data extends AbstractHelper
 
     /**
      * @return array
-     * @throws FileSystemException
-     * @throws \Magento\Framework\Exception\RuntimeException
      */
     public function collectModuleConfig(): array
     {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -164,7 +164,7 @@ class Data extends AbstractHelper
      */
     public function getStoreId():int
     {
-        return $this->getStore()->getId() ?? 0;
+        return $this->getStore()?->getId() ?? 0;
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -184,7 +184,7 @@ class Data extends AbstractHelper
         try {
             $this->config[$this->getStoreId()]['enabled'] = $this->scopeConfig->getValue('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)
                 ?? $this->deploymentConfig->get('sentry') !== null;
-        } catch (TableNotFoundException | FileSystemException | RuntimeException $e) {
+        } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
             $this->config[$this->getStoreId()]['enabled'] = null;
         }
 
@@ -192,7 +192,7 @@ class Data extends AbstractHelper
             try {
                 $this->config[$this->getStoreId()][$value] = $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
                     ?? $this->deploymentConfig->get('sentry/'.$value);
-            } catch (TableNotFoundException | FileSystemException | RuntimeException $e) {
+            } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
                 $this->config[$this->getStoreId()][$value] = null;
             }
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -162,7 +162,7 @@ class Data extends AbstractHelper
     /**
      * @return int
      */
-    public function getStoreId():int
+    public function getStoreId(): int
     {
         return $this->getStore()?->getId() ?? 0;
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,10 +14,10 @@ use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\DB\Adapter\TableNotFoundException;
 use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\Exception\RuntimeException;
 use Throwable;
 
 class Data extends AbstractHelper

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -81,7 +81,6 @@ class Data extends AbstractHelper
      */
     public function getDSN()
     {
-
         return $this->collectModuleConfig()['dsn'];
     }
 
@@ -256,6 +255,7 @@ class Data extends AbstractHelper
     public function isOverwriteProductionMode(): bool
     {
         $config = $this->collectModuleConfig();
+
         return isset($config['mage_mode_development']) && $config['mage_mode_development'];
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -9,65 +9,65 @@
             <label>Sentry configuration</label>
             <tab>justbetter</tab>
             <resource>JustBetter_Sentry::configuration</resource>
-            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                 <label>Sentry general config</label>
-                <field id="deployment_config_info" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="deployment_config_info" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Deployment config info</label>
                     <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\DeploymentConfigInfo</frontend_model>
                 </field>
-                <field id="enable_php_tracking" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_php_tracking" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Enable PHP Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_script_tag" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_script_tag" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Enable Javascript Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="script_tag_placement" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="script_tag_placement" translate="label" type="select" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Script tag location</label>
                     <source_model>JustBetter\Sentry\Model\Config\Source\ScriptTagPlacement</source_model>
                     <depends>
                         <field id="enable_script_tag">1</field>
                     </depends>
                 </field>
-                <field id="enable_session_replay" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_session_replay" translate="label" type="select" sortOrder="40" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Enable Session Replay</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="replay_session_sample_rate" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="replay_session_sample_rate" translate="label" type="text" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Session Sample Rate</label>
                     <depends>
                         <field id="enable_session_replay">1</field>
                     </depends>
                 </field>
-                <field id="replay_error_sample_rate" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="replay_error_sample_rate" translate="label" type="text" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Error Sample Rate</label>
                     <depends>
                         <field id="enable_session_replay">1</field>
                     </depends>
                 </field>
-                <field id="replay_block_media" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="replay_block_media" translate="label" type="select" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Block Media</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enable_session_replay">1</field>
                     </depends>
                 </field>
-                <field id="replay_mask_text" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="replay_mask_text" translate="label" type="select" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Mask text</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enable_session_replay">1</field>
                     </depends>
                 </field>
-                <field id="use_logrocket" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="use_logrocket" translate="label" type="select" sortOrder="40" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Use LogRocket</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enable_script_tag">1</field>
                     </depends>
                 </field>
-                <field id="logrocket_identify" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="logrocket_identify" translate="label" type="select" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>LogRocket include user data</label>
                     <tooltip>Include user ID, name and email to identify logged in users in LogRocket</tooltip>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -82,46 +82,46 @@
                     <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\Button</frontend_model>
                 </field>
             </group>
-            <group id="environment" translate="label comment" sortOrder="20" showInDefault="1" showInStore="0" showInWebsite="0">
+            <group id="environment" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                 <label>Environment Configuration</label>
                 <comment><![CDATA[Setting the configuration here will override the Magento Deployment Configuration.]]></comment>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="dsn" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="dsn" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>DSN</label>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="logrocket_key" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="logrocket_key" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Logrocket Key</label>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="environment" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="environment" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Environment</label>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="log_level" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="log_level" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Log Level</label>
                     <source_model>JustBetter\Sentry\Model\Config\Source\LogLevel</source_model>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="tracing_enabled" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="tracing_enabled" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Tracing Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="tracing_sample_rate" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="tracing_sample_rate" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Tracing Sample Rate</label>
                     <validate>validate-not-negative-number validate-number</validate>
                     <depends>
@@ -129,14 +129,14 @@
                     </depends>
                 </field>
             </group>
-            <group id="issue_grouping" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+            <group id="issue_grouping" translate="label" type="text" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                 <label>Sentry issue grouping</label>
                 <comment><![CDATA[Sentry does its best to group related issues, but due to some parts in most Magento URL's, Sentry inadvertently does not group these issues although they might be related. Stripping out these values from the URL helps with this.]]></comment>
-                <field id="strip_static_content_version"  translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="strip_static_content_version"  translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Strip static version from URL</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="strip_store_code" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="strip_store_code" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Strip store code from URL</label>
                     <comment><![CDATA[Caution: this will replace all occurrences of your storecode in the URL, which might cause issues when the store code is too generic.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
**Summary**

This pull request aims to add the ability to use distinct configuration per Magento Stores or Websites.  We use it for a multi-website Magento where one Website is legacy and based on Luma and the Other one is based on Hyva theme. 

As two different teams are working on the distinct websites, and to avoid merging issues between them, I needed to be able to customize the "dsn" and other configurations per website.

I also added the ability in the configuration to have the checkbox “can restore” on all config fields. So I can version a default configuration for each website on a config.xml file without blocking the ability to edit them through the configuration if needed.

An example of config.xml file : 
```
<default>
        <sentry>
            <general>
                <enable_script_tag>1</enable_script_tag>
                <script_tag_placement>before.body.end</script_tag_placement>
                <enable_session_replay>1</enable_session_replay>
                <replay_session_sample_rate>0.0</replay_session_sample_rate>
                <replay_error_sample_rate>1.0</replay_error_sample_rate>
                <replay_block_media>0</replay_block_media>
                <replay_mask_text>0</replay_mask_text>
                <use_logrocket>0</use_logrocket>
                <enable_php_tracking>1</enable_php_tracking>
            </general>
            <environment>
                <enabled>1</enabled>
                <environment>local</environment>
                <tracing_enabled>1</tracing_enabled>
                <tracing_sample_rate>1.0</tracing_sample_rate>
                <dsn>***/1</dsn>
                <log_level>300</log_level>
                <mage_mode_development>1</mage_mode_development>
                <errorexception_reporting>32767</errorexception_reporting>
            </environment>
            <issue_grouping>
                <strip_static_content_version>1</strip_static_content_version>
                <strip_store_code>0</strip_store_code>
            </issue_grouping>
        </sentry>
    </default>
    <websites>
        <websiteone>
            <sentry>
                <environment>
                    <dsn>***/2</dsn>
                </environment>
            </sentry>
        </websiteone>
        <websitetwo>
            <sentry>
                <environment>
                    <dsn>***/3</dsn>
                </environment>
            </sentry>
        </bultex>
    </websitetwo>
```

The only element I kept in the env.php is the environment name (staging or production): 
```
 'system' => [
        'default' => [
             'sentry' => [
                    'environment' => "staging"
             ]
        ]
]
```
