### PR TITLE
remove promise-polyfill

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,7 +3,6 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="polyfill" type="host">https://polyfill-fastly.io</value>
                 <value id="sentry-cdn" type="host">https://browser.sentry-cdn.com</value>
             </values>
         </policy>

--- a/view/frontend/templates/script/sentry.phtml
+++ b/view/frontend/templates/script/sentry.phtml
@@ -25,7 +25,6 @@ $remoteFile = sprintf(
 );
 ?>
 
-<script src="https://polyfill-fastly.io/v2/polyfill.min.js?features=Promise" crossorigin></script>
 <script src="<?= /** @noEscape */$remoteFile ?>" crossorigin="anonymous"></script>
 <script>
 if (typeof Sentry !== 'undefined') {


### PR DESCRIPTION
This PR removes the Polyfill for Promises.

Magento does not Support IE anymore in the latest releases, so we do not need the Promise-Polyfill, because all browsers does support Promises (fully)

Please also see: https://caniuse.com/?search=promise
(I think we can ignore the Opera Mini)

