### PR TITLE
fix overriding configuration

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -85,25 +85,36 @@
             <group id="environment" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                 <label>Environment Configuration</label>
                 <comment><![CDATA[Setting the configuration here will override the Magento Deployment Configuration.]]></comment>
+                <field id="override" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Override environment configuration</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If enabled, the deployment configuration from env.php got overridden by the following fields. Reset fields to system value, if you want to use the deployment configuration from env.php</comment>
+                </field>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="override">1</field>
+                    </depends>
                 </field>
                 <field id="dsn" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
                     <label>DSN</label>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
                 <field id="logrocket_key" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Logrocket Key</label>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
                 <field id="environment" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
                     <label>Environment</label>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
@@ -111,13 +122,15 @@
                     <label>Log Level</label>
                     <source_model>JustBetter\Sentry\Model\Config\Source\LogLevel</source_model>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="tracing_enabled" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
+                <field id="tracing_enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Tracing Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>
@@ -125,6 +138,7 @@
                     <label>Tracing Sample Rate</label>
                     <validate>validate-not-negative-number validate-number</validate>
                     <depends>
+                        <field id="override">1</field>
                         <field id="enabled">1</field>
                     </depends>
                 </field>


### PR DESCRIPTION
This fixes an issue that if you save the configuration within the administration, the sentry error reporting got disabled, because of the setting `sentry/environment/enabled`

this PR will add another setting with which it is possible to enable to override.
Only if the override is enabled, it is possible to disable the Sentry error tracking. 

Also reworked the `collectModuleConfig` within the config-helper to make sure that values, which are null or empty, do not override the deployment configuration.

I added `canRestore` to the system.xml to make sure that no empty values got stored into the database. 

I removed the TableNotFoundException-Handling, because i do not see a case when this could happen.
