### PR TITLE
Lazily get user context if we should be able to

### DIFF
--- a/Model/SentryInteraction.php
+++ b/Model/SentryInteraction.php
@@ -22,13 +22,16 @@ use function Sentry\init;
 class SentryInteraction
 {
     /**
+     * @var ?UserContextInterface $userContext
+     */
+    private ?UserContextInterface $userContext = null;
+
+    /**
      * SentryInteraction constructor.
      *
-     * @param UserContextInterface $userContext
-     * @param State                $appState
+     * @param State $appState
      */
     public function __construct(
-        private UserContextInterface $userContext,
         private State $appState
     ) {
     }
@@ -44,11 +47,38 @@ class SentryInteraction
     {
         init($config);
     }
+    
+    /**
+     * Check if we might be able to get user context.
+     */
+    public function canGetUserContext()
+    {
+        try {
+            // @phpcs:ignore Generic.PHP.NoSilencedErrors
+            return in_array(@$this->appState->getAreaCode(), [Area::AREA_ADMINHTML, Area::AREA_FRONTEND, Area::AREA_WEBAPI_REST, Area::AREA_WEBAPI_SOAP, Area::AREA_GRAPHQL]);
+        } catch (LocalizedException $ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Attempt to get userContext from the objectManager, so we don't request it too early.
+     */
+    public function getUserContext(): ?UserContextInterface
+    {
+        if ($this->userContext) {
+            return $this->userContext;
+        }
+
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+
+        return $this->userContext = $objectManager->get(UserContextInterface::class);
+    }
 
     /**
      * Check if we might be able to get the user data.
      */
-    private function canGetUserData()
+    public function canGetUserData()
     {
         try {
             // @phpcs:ignore Generic.PHP.NoSilencedErrors
@@ -120,12 +150,14 @@ class SentryInteraction
         \Magento\Framework\Profiler::start('SENTRY::add_user_context');
 
         try {
-            $userId = $this->userContext->getUserId();
-            if ($userId) {
-                $userType = $this->userContext->getUserType();
+            if ($this->canGetUserContext()) {
+                $userId = $this->getUserContext()->getUserId();
+                if ($userId) {
+                    $userType = $this->getUserContext()->getUserType();
+                }
             }
 
-            if ($this->canGetUserData() && count($userData = $this->getSessionUserData())) {
+            if (count($userData = $this->getSessionUserData())) {
                 $userId = $userData['id'] ?? $userId;
                 $userType = $userData['user_type'] ?? $userType;
                 unset($userData['user_type']);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Fixes: https://github.com/justbetter/magento2-sentry/issues/79#issuecomment-2476730789

In some cases the user may be logged out because we inject the `UserContextInterface` before Magento has had the chance to populate it.

**Result**

With this change we check wether the area code can be fetched, and if it is an area code where user context might be available.
And **only then** inject the userContext so. This should ensure user context is already compiled and added.

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run phpstan`