### PR TITLE
use config only if enabled otherwise just deployment-config

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -12,8 +12,6 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\State;
-use Magento\Framework\DB\Adapter\TableNotFoundException;
-use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
@@ -211,18 +209,18 @@ class Data extends AbstractHelper
             return $this->config[$storeId];
         }
 
-        if (! $this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
+        if (!$this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
             $this->config[$storeId]['enabled'] = $this->deploymentConfig->get('sentry') !== null;
         } else {
             $this->config[$storeId]['enabled'] = true;
         }
 
         foreach ($this->configKeys as $value) {
-            if (! $this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
-                $this->config[$storeId][$value] = $this->deploymentConfig->get('sentry/' . $value);
+            if (!$this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
+                $this->config[$storeId][$value] = $this->deploymentConfig->get('sentry/'.$value);
             } else {
-                $this->config[$storeId][$value] = $this->scopeConfig->getValue('sentry/environment/' . $value, ScopeInterface::SCOPE_STORE)
-                    ?? $this->deploymentConfig->get('sentry/' . $value);
+                $this->config[$storeId][$value] = $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
+                    ?? $this->deploymentConfig->get('sentry/'.$value);
             }
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -211,19 +211,18 @@ class Data extends AbstractHelper
             return $this->config[$storeId];
         }
 
-        try {
-            $this->config[$storeId]['enabled'] = $this->scopeConfig->getValue('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)
-                ?? $this->deploymentConfig->get('sentry') !== null;
-        } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
-            $this->config[$storeId]['enabled'] = null;
+        if (! $this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
+            $this->config[$storeId]['enabled'] = $this->deploymentConfig->get('sentry') !== null;
+        } else {
+            $this->config[$storeId]['enabled'] = true;
         }
 
         foreach ($this->configKeys as $value) {
-            try {
-                $this->config[$storeId][$value] = $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
-                    ?? $this->deploymentConfig->get('sentry/'.$value);
-            } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
-                $this->config[$storeId][$value] = null;
+            if (! $this->scopeConfig->isSetFlag('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)) {
+                $this->config[$storeId][$value] = $this->deploymentConfig->get('sentry/' . $value);
+            } else {
+                $this->config[$storeId][$value] = $this->scopeConfig->getValue('sentry/environment/' . $value, ScopeInterface::SCOPE_STORE)
+                    ?? $this->deploymentConfig->get('sentry/' . $value);
             }
         }
 


### PR DESCRIPTION
**Summary**
I noticed some weird behavior with the config. When you try to override in the backend by enabling `sentry/environment/enabled` and then disable it, sentry is just always disabled, like described here: https://github.com/justbetter/magento2-sentry/issues/128 so I fixed it by just checking if it is enabled or not and if it is not it just uses the deployment-config. Also for the additional settings, because the `log_level` was overridden by the setting, because it is a source model it always has a value when saved. Now the overridden values are only used when `sentry/environment/enabled` flag is true. 

I also saw this PR https://github.com/justbetter/magento2-sentry/pull/144 which is great, but also adds another setting and in my opinion the enabled setting can just be used instead of an extra override setting. So basically this PR also does this, and indeed the try catches are not needed. 

I deliberately used a simple if/else to make it more readable, it could be fancier, but I think a readable solution is better here.

**Result**

Deployment-config is always leading for enabling the service. But when backend config is used settings can be overridden only if `sentry/environment/enabled` is true, in that case backend config is used over deployment-config. When a setting like DSN is not filled in de backend config, it just falls back to the deployment config

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run phpstan`