### PR TITLE
Fix Monolog changes due to Magento2 2.4.8 Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=8.0",
     "sentry/sdk": "^4.0",
-    "monolog/monolog": ">=2.7.0",
+    "monolog/monolog": ">=3.0",
     "magento/framework": "*",
     "nyholm/psr7": "^1.2",
     "magento/module-config": "^101.2"


### PR DESCRIPTION
* Fixes method signature of monolog plugin for monolog/monolog depencency >v3 (updated constraint from magento2 v2.4.8 upgrade)
* updates monolog dependency to >=v3