### PR TITLE
Moved sentry logging to a monolog handler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,4 @@
 **Checklist**
 
 - [ ] I've ran `composer run codestyle`
-- [ ] I've ran `composer run phpstan`
+- [ ] I've ran `composer run analyse`

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -9,7 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: analyse
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHPStan - P${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -18,12 +24,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Analyse
         run: composer run analyse

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,7 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: PHPCS
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHPCS - P${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -18,12 +24,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Analyse
         run: composer run phpcs

--- a/Helper/Version.php
+++ b/Helper/Version.php
@@ -36,7 +36,7 @@ class Version extends AbstractHelper
     public function __construct(
         private \Magento\Framework\App\State $appState,
         private \Magento\Framework\App\View\Deployment\Version\StorageInterface $versionStorage,
-        DeploymentConfig $deploymentConfig = null
+        ?DeploymentConfig $deploymentConfig = null
     ) {
         $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(DeploymentConfig::class);
     }

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -10,7 +10,7 @@ use Monolog\Logger;
 use Monolog\LogRecord;
 
 // TODO: Remove once V2 support is dropped.
-// phpcs:disable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration
+// phpcs:disable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration,PSR1.Classes.ClassDeclaration.MultipleClasses
 if (Logger::API < 3) {
     class Sentry extends AbstractHandler
     {
@@ -35,7 +35,9 @@ if (Logger::API < 3) {
         public function isHandling(array $record): bool
         {
             $config = $this->sentryHelper->collectModuleConfig();
-            $this->setLevel($config['log_level']);
+            if ($config['log_level']) {
+                $this->setLevel($config['log_level']);
+            }
 
             return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
         }
@@ -78,7 +80,9 @@ if (Logger::API < 3) {
         public function isHandling(LogRecord $record): bool
         {
             $config = $this->sentryHelper->collectModuleConfig();
-            $this->setLevel($config['log_level']);
+            if ($config['log_level']) {
+                $this->setLevel($config['log_level']);
+            }
 
             return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
         }
@@ -98,4 +102,4 @@ if (Logger::API < 3) {
         }
     }
 }
-// phpcs:enable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration
+// phpcs:enable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration,PSR1.Classes.ClassDeclaration.MultipleClasses

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace JustBetter\Sentry\Logger\Handler;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\SentryLog;
+use Magento\Framework\App\DeploymentConfig;
+use Monolog\Handler\AbstractHandler;
+
+class Sentry extends AbstractHandler
+{
+    public function __construct(
+        protected Data $sentryHelper,
+        protected SentryLog $sentryLog,
+        protected DeploymentConfig $deploymentConfig,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isHandling(array $record): bool
+    {
+        $config = $this->sentryHelper->collectModuleConfig();
+        $this->setLevel((int) $config['log_level']);
+
+        return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $record): bool
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        $this->sentryLog->send($record['message'], $record['level'], $record['context']);
+
+        return false;
+    }
+}

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -27,7 +27,7 @@ class Sentry extends AbstractHandler
     /**
      * @inheritDoc
      */
-    public function isHandling(array $record): bool
+    public function isHandling($record): bool
     {
         $config = $this->sentryHelper->collectModuleConfig();
         $this->setLevel($config['log_level']);
@@ -38,7 +38,7 @@ class Sentry extends AbstractHandler
     /**
      * @inheritDoc
      */
-    public function handle(array $record): bool
+    public function handle($record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -30,7 +30,7 @@ class Sentry extends AbstractHandler
     public function isHandling(array $record): bool
     {
         $config = $this->sentryHelper->collectModuleConfig();
-        $this->setLevel((int) $config['log_level']); // @phpstan-ignore-line
+        $this->setLevel($config['log_level']);
 
         return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
     }

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -9,6 +9,13 @@ use Monolog\Handler\AbstractHandler;
 
 class Sentry extends AbstractHandler
 {
+    /**
+     * Construct.
+     *
+     * @param Data $sentryHelper
+     * @param SentryLog $sentryLog
+     * @param DeploymentConfig $deploymentConfig
+     */
     public function __construct(
         protected Data $sentryHelper,
         protected SentryLog $sentryLog,
@@ -18,18 +25,18 @@ class Sentry extends AbstractHandler
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function isHandling(array $record): bool
     {
         $config = $this->sentryHelper->collectModuleConfig();
-        $this->setLevel((int) $config['log_level']);
+        $this->setLevel((int) $config['log_level']); // @phpstan-ignore-line
 
         return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function handle(array $record): bool
     {

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -6,46 +6,96 @@ use JustBetter\Sentry\Helper\Data;
 use JustBetter\Sentry\Model\SentryLog;
 use Magento\Framework\App\DeploymentConfig;
 use Monolog\Handler\AbstractHandler;
+use Monolog\Logger;
+use Monolog\LogRecord;
 
-class Sentry extends AbstractHandler
-{
-    /**
-     * Construct.
-     *
-     * @param Data             $sentryHelper
-     * @param SentryLog        $sentryLog
-     * @param DeploymentConfig $deploymentConfig
-     */
-    public function __construct(
-        protected Data $sentryHelper,
-        protected SentryLog $sentryLog,
-        protected DeploymentConfig $deploymentConfig,
-    ) {
-        parent::__construct();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function isHandling($record): bool
+// TODO: Remove once V2 support is dropped.
+// phpcs:disable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration
+if (Logger::API < 3) {
+    class Sentry extends AbstractHandler
     {
-        $config = $this->sentryHelper->collectModuleConfig();
-        $this->setLevel($config['log_level']);
-
-        return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function handle($record): bool
-    {
-        if (!$this->isHandling($record)) {
-            return false;
+        /**
+         * Construct.
+         *
+         * @param Data             $sentryHelper
+         * @param SentryLog        $sentryLog
+         * @param DeploymentConfig $deploymentConfig
+         */
+        public function __construct(
+            protected Data $sentryHelper,
+            protected SentryLog $sentryLog,
+            protected DeploymentConfig $deploymentConfig,
+        ) {
+            parent::__construct();
         }
 
-        $this->sentryLog->send($record['message'], $record['level'], $record['context']);
+        /**
+         * @inheritDoc
+         */
+        public function isHandling(array $record): bool
+        {
+            $config = $this->sentryHelper->collectModuleConfig();
+            $this->setLevel($config['log_level']);
 
-        return false;
+            return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
+        }
+
+        /**
+         * @inheritDoc
+         */
+        public function handle(array $record): bool
+        {
+            if (!$this->isHandling($record)) {
+                return false;
+            }
+
+            $this->sentryLog->send($record['message'], $record['level'], $record['context']);
+
+            return false;
+        }
+    }
+} else {
+    class Sentry extends AbstractHandler
+    {
+        /**
+         * Construct.
+         *
+         * @param Data             $sentryHelper
+         * @param SentryLog        $sentryLog
+         * @param DeploymentConfig $deploymentConfig
+         */
+        public function __construct(
+            protected Data $sentryHelper,
+            protected SentryLog $sentryLog,
+            protected DeploymentConfig $deploymentConfig,
+        ) {
+            parent::__construct();
+        }
+
+        /**
+         * @inheritDoc
+         */
+        public function isHandling(LogRecord $record): bool
+        {
+            $config = $this->sentryHelper->collectModuleConfig();
+            $this->setLevel($config['log_level']);
+
+            return parent::isHandling($record) && $this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive();
+        }
+
+        /**
+         * @inheritDoc
+         */
+        public function handle(LogRecord $record): bool
+        {
+            if (!$this->isHandling($record)) {
+                return false;
+            }
+
+            $this->sentryLog->send($record['message'], $record['level'], $record['context']);
+
+            return false;
+        }
     }
 }
+// phpcs:enable Generic.Classes.DuplicateClassName,PSR2.Classes.ClassDeclaration

--- a/Logger/Handler/Sentry.php
+++ b/Logger/Handler/Sentry.php
@@ -12,8 +12,8 @@ class Sentry extends AbstractHandler
     /**
      * Construct.
      *
-     * @param Data $sentryHelper
-     * @param SentryLog $sentryLog
+     * @param Data             $sentryHelper
+     * @param SentryLog        $sentryLog
      * @param DeploymentConfig $deploymentConfig
      */
     public function __construct(

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -99,12 +99,12 @@ class SentryLog
     {
         return EventHint::fromArray(
             [
-                'exception' => ($context['exception'] ?? null) instanceof \Throwable ? $context['exception'] : null,
-                'mechanism' => ($context['mechanism'] ?? null) instanceof ExceptionMechanism ? $context['mechanism'] : null,
+                'exception'  => ($context['exception'] ?? null) instanceof \Throwable ? $context['exception'] : null,
+                'mechanism'  => ($context['mechanism'] ?? null) instanceof ExceptionMechanism ? $context['mechanism'] : null,
                 'stacktrace' => ($context['stacktrace'] ?? null) instanceof Stacktrace ? $context['stacktrace'] : null,
-                'extra' => array_filter(
+                'extra'      => array_filter(
                     $context,
-                    fn($key) => !in_array($key, ['exception', 'mechanism', 'stacktrace']),
+                    fn ($key) => !in_array($key, ['exception', 'mechanism', 'stacktrace']),
                     ARRAY_FILTER_USE_KEY
                 ) ?: [],
             ]

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -8,10 +8,9 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\SessionException;
-use Magento\Framework\Logger\Monolog;
 use Sentry\State\Scope as SentryScope;
 
-class SentryLog extends Monolog
+class SentryLog
 {
     /**
      * @var array
@@ -21,24 +20,17 @@ class SentryLog extends Monolog
     /**
      * SentryLog constructor.
      *
-     * @param string            $name
      * @param Data              $data
      * @param Session           $customerSession
      * @param State             $appState
      * @param SentryInteraction $sentryInteraction
-     * @param array             $handlers
-     * @param array             $processors
      */
     public function __construct(
-        $name,
         protected Data $data,
         protected Session $customerSession,
         private State $appState,
         private SentryInteraction $sentryInteraction,
-        array $handlers = [],
-        array $processors = []
     ) {
-        parent::__construct($name, $handlers, $processors);
     }
 
     /**

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -4,6 +4,8 @@ namespace JustBetter\Sentry\Plugin;
 
 use JustBetter\Sentry\Logger\Handler\Sentry;
 use Magento\Framework\Logger\Monolog;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
 
 class MonologPlugin extends Monolog
 {
@@ -14,6 +16,8 @@ class MonologPlugin extends Monolog
      * @param Sentry                              $sentryHandler
      * @param \Monolog\Handler\HandlerInterface[] $handlers      Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]                          $processors    Optional array of processors
+     * 
+     * @phpstan-param array<(callable(LogRecord|array): LogRecord|array)|ProcessorInterface> $processors
      */
     public function __construct(
         $name,

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -3,6 +3,7 @@
 namespace JustBetter\Sentry\Plugin;
 
 use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Logger\Handler\Sentry;
 use JustBetter\Sentry\Model\SentryLog;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Logger\Monolog;
@@ -22,36 +23,12 @@ class MonologPlugin extends Monolog
      */
     public function __construct(
         $name,
-        protected Data $sentryHelper,
-        protected SentryLog $sentryLog,
-        protected DeploymentConfig $deploymentConfig,
+        Sentry $sentryHandler,
         array $handlers = [],
         array $processors = []
     ) {
+        $handlers['sentry'] = $sentryHandler;
+
         parent::__construct($name, $handlers, $processors);
-    }
-
-    /**
-     * Adds a log record to Sentry.
-     *
-     * @param int               $level    The logging level
-     * @param string            $message  The log message
-     * @param array             $context  The log context
-     * @param DateTimeImmutable $datetime Datetime of log
-     *
-     * @return bool Whether the record has been processed
-     */
-    public function addRecord(
-        int $level,
-        string $message,
-        array $context = [],
-        DateTimeImmutable $datetime = null
-    ): bool {
-        if ($this->deploymentConfig->isAvailable() && $this->sentryHelper->isActive()) {
-            $this->sentryLog->send($message, $level, $context);
-        }
-
-        // @phpstan-ignore argument.type
-        return parent::addRecord($level, $message, $context, $datetime);
     }
 }

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -16,7 +16,7 @@ class MonologPlugin extends Monolog
      * @param Sentry                              $sentryHandler
      * @param \Monolog\Handler\HandlerInterface[] $handlers      Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]                          $processors    Optional array of processors
-     * 
+     *
      * @phpstan-param array<(callable(LogRecord|array): LogRecord|array)|ProcessorInterface> $processors
      */
     public function __construct(

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -2,12 +2,8 @@
 
 namespace JustBetter\Sentry\Plugin;
 
-use JustBetter\Sentry\Helper\Data;
 use JustBetter\Sentry\Logger\Handler\Sentry;
-use JustBetter\Sentry\Model\SentryLog;
-use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Logger\Monolog;
-use Monolog\DateTimeImmutable;
 
 class MonologPlugin extends Monolog
 {
@@ -15,9 +11,7 @@ class MonologPlugin extends Monolog
      * @psalm-param array<callable(array): array> $processors
      *
      * @param string                              $name             The logging channel, a simple descriptive name that is attached to all log records
-     * @param Data                                $sentryHelper
-     * @param SentryLog                           $sentryLog
-     * @param DeploymentConfig                    $deploymentConfig
+     * @param Sentry                              $sentryHandler
      * @param \Monolog\Handler\HandlerInterface[] $handlers         Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]                          $processors       Optional array of processors
      */

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -10,10 +10,10 @@ class MonologPlugin extends Monolog
     /**
      * @psalm-param array<callable(array): array> $processors
      *
-     * @param string                              $name             The logging channel, a simple descriptive name that is attached to all log records
+     * @param string                              $name          The logging channel, a simple descriptive name that is attached to all log records
      * @param Sentry                              $sentryHandler
-     * @param \Monolog\Handler\HandlerInterface[] $handlers         Optional stack of handlers, the first one in the array is called first, etc.
-     * @param callable[]                          $processors       Optional array of processors
+     * @param \Monolog\Handler\HandlerInterface[] $handlers      Optional stack of handlers, the first one in the array is called first, etc.
+     * @param callable[]                          $processors    Optional array of processors
      */
     public function __construct(
         $name,

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "sentry/sdk": "^4.0",
     "monolog/monolog": ">=2.7.0|^3.0",
     "magento/framework": "*",
+    "magento/module-csp": "*",
     "nyholm/psr7": "^1.2",
     "magento/module-config": "^101.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "analyse": "vendor/bin/phpstan analyse --memory-limit='1G'",
-    "phpcs": "vendor/bin/phpcs --colors --standard=vendor/magento/magento-coding-standard/Magento2 --exclude=Generic.Files.LineLength --report=full,summary,gitblame --extensions=php,phtml --ignore=./vendor ./",
+    "phpcs": "vendor/bin/phpcs --colors --standard=vendor/magento/magento-coding-standard/Magento2 -s --exclude=Generic.Files.LineLength --report=full,summary,gitblame --extensions=php,phtml --ignore=./vendor ./",
     "phpcbf": "vendor/bin/phpcbf --colors --standard=vendor/magento/magento-coding-standard/Magento2 --exclude=Generic.Files.LineLength --extensions=php,phtml --ignore=./vendor ./ || exit 0",
     "codestyle": [
       "@phpcbf",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=8.0",
     "sentry/sdk": "^4.0",
-    "monolog/monolog": ">=2.7.0",
+    "monolog/monolog": ">=2.7.0|^3.0",
     "magento/framework": "*",
     "nyholm/psr7": "^1.2",
     "magento/module-config": "^101.2"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,28 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="JustBetter\Sentry\Model\SentryLog">
-        <arguments>
-            <argument name="name" xsi:type="string">SentryLog</argument>
-            <argument name="handlers" xsi:type="array">
-                <item name="system" xsi:type="object">Magento\Framework\Logger\Handler\System</item>
-            </argument>
-            <argument name="processors" xsi:type="array"/>
-            <argument name="customerSession" xsi:type="object">Magento\Customer\Model\Session\Proxy</argument>
-        </arguments>
-    </type>
-
-    <type name="JustBetter\Sentry\Plugin\MonologPlugin">
-        <arguments>
-            <argument name="name" xsi:type="string"></argument>
-            <argument name="data" xsi:type="object">JustBetter\Sentry\Helper\Data\Proxy</argument>
-            <argument name="sentryLog" xsi:type="object">JustBetter\Sentry\Model\SentryLog\Proxy</argument>
-            <argument name="deploymentConfig" xsi:type="object">Magento\Framework\App\DeploymentConfig\Proxy</argument>
-            <argument name="handlers" xsi:type="array"></argument>
-            <argument name="processors" xsi:type="array"></argument>
-        </arguments>
-    </type>
-
     <!-- Cannot use plugin https://github.com/magento/magento2/issues/14950 -->
     <preference for="Magento\Framework\Logger\Monolog" type="JustBetter\Sentry\Plugin\MonologPlugin"/>
     <type name="Magento\Framework\AppInterface">
@@ -42,5 +20,4 @@
             </argument>
         </arguments>
     </type>
-
 </config>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,4 +6,5 @@ parameters:
     excludePaths:
         - vendor
         - Test/*
+        - Logger/Handler/Sentry.php
     level: 5


### PR DESCRIPTION
**Summary**

In order to improve update survivability this PR moves the monolog handlers away from a preference and into it's own handler

**Result**

Functionality wise everything will stay the same, but since we're in a handler now we no longer need to worry about type changes on addRecord 

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run phpstan`