### PR TITLE
Pass config also relevant to sentry

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -468,7 +468,7 @@ class Data extends AbstractHelper
      */
     public function getErrorExceptionReporting(): int
     {
-        return (int) ($this->collectModuleConfig()['errorexception_reporting'] ?? E_ALL);
+        return (int) ($this->collectModuleConfig()['errorexception_reporting'] ?? error_reporting());
     }
 
     /**

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -76,6 +76,9 @@ class GlobalExceptionCatcher
             static fn (IntegrationInterface $integration) => !in_array(get_class($integration), $disabledDefaultIntegrations)
         ));
 
+        $config->setIgnoreExceptions($this->sentryHelper->getIgnoreExceptions());
+        $config->setErrorTypes($this->sentryHelper->getErrorExceptionReporting());
+
         $this->eventManager->dispatch('sentry_before_init', [
             'config' => $config,
         ]);


### PR DESCRIPTION
**Summary**

Sentry has now added some options that work the same as this package, for the sake of completion we now pass them through to Sentry as well. 

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`