### PR TITLE
Gather ip from Magento instead of server variable

### DIFF
--- a/Model/SentryInteraction.php
+++ b/Model/SentryInteraction.php
@@ -6,20 +6,20 @@ namespace JustBetter\Sentry\Model;
 
 // phpcs:disable Magento2.Functions.DiscouragedFunction
 
-use function Sentry\captureException;
-use function Sentry\configureScope;
-use function Sentry\init;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\Model\Auth\Session as AdminSession;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
-
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Framework\ObjectManager\ConfigInterface;
 use ReflectionClass;
 use Sentry\State\Scope;
+
+use function Sentry\captureException;
+use function Sentry\configureScope;
+use function Sentry\init;
 
 class SentryInteraction
 {


### PR DESCRIPTION
**Summary**

This PR uses Magento's `getRemoteAddress` to get a proper ip address back instead of the default REMOTE_ADDRESS server variable which usually only contains the current servers or proxy servers ip address

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`