### PR TITLE
Automatically pass all supported sentry config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 composer.lock
 /vendor
+vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [4.1.0] - 2025-06-04
+### Added
+    * Clean up the Magento stacktrace before sending it to Sentry (https://github.com/justbetter/magento2-sentry/pull/171)
+    * Pass config also relevant to sentry (https://github.com/justbetter/magento2-sentry/pull/172)
+### Fixed 
+    * Gather ip from Magento instead of server variable (https://github.com/justbetter/magento2-sentry/pull/174)
 ## [4.0.1] - 2025-05-06
 ### Fixed 
     * Load customerSession in SentryLog via proxy (Fixing https://github.com/justbetter/magento2-sentry/issues/160) (https://github.com/justbetter/magento2-sentry/pull/169) thanks to https://github.com/brosenberger

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -243,12 +243,14 @@ class Data extends AbstractHelper
     /**
      * Parse the config value to the type defined in the config.
      *
-     * @param mixed               $value
-     * @param array{type: string} $config
+     * @param mixed $value
+     * @param array $config
+     *
+     * @return mixed
      */
     public function processConfigValue(mixed $value, array $config): mixed
     {
-        if (is_null($value)) {
+        if ($value === null) {
             return null;
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -27,6 +27,7 @@ class Data extends AbstractHelper
     public const NATIVE_SENTRY_CONFIG_KEYS = [
         // https://docs.sentry.io/platforms/php/configuration/options/#core-options
         'dsn'                   => ['type' => 'string'],
+        'environment'           => ['type' => 'string'],
         'max_breadcrumbs'       => ['type' => 'int'],
         'attach_stacktrace'     => ['type' => 'bool'],
         'send_default_pii'      => ['type' => 'bool'],
@@ -71,7 +72,6 @@ class Data extends AbstractHelper
         'log_level'                           => ['type' => 'int'],
         'errorexception_reporting'            => ['type' => 'int'], /* @deprecated by @see: error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types */
         'mage_mode_development'               => ['type' => 'bool'],
-        'environment'                         => ['type' => 'string'],
         'js_sdk_version'                      => ['type' => 'string'],
         'tracing_enabled'                     => ['type' => 'bool'],
         'tracing_sample_rate'                 => ['type' => 'float'], /* @deprecated by @see: traces_sample_rate https://docs.sentry.io/platforms/php/configuration/options/#error_types */

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -44,7 +44,8 @@ class Data extends AbstractHelper
         'traces_sample_rate'        => ['type' => 'float'],
         'ignore_transactions'       => ['type' => 'array'],
         'trace_propagation_targets' => ['type' => 'array'],
-        'profiles_sample_rate',     => ['type' => 'float'],
+        // https://docs.sentry.io/platforms/php/profiling/#enabling-profiling
+        'profiles_sample_rate'      => ['type' => 'float'],
         // https://docs.sentry.io/platforms/php/configuration/options/#transport-options
         'http_proxy'           => ['type' => 'string'],
         'http_connect_timeout' => ['type' => 'int'],
@@ -68,12 +69,12 @@ class Data extends AbstractHelper
         ...self::NATIVE_SENTRY_CONFIG_KEYS,
         'logrocket_key'                => ['type' => 'array'],
         'log_level'                    => ['type' => 'int'],
-        'errorexception_reporting'     => ['type' => 'int'], // Deprecated by error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types
+        'errorexception_reporting'     => ['type' => 'int'], /* @deprecated by @see: error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types */
         'mage_mode_development'        => ['type' => 'bool'],
         'environment'                  => ['type' => 'string'],
         'js_sdk_version'               => ['type' => 'string'],
         'tracing_enabled'              => ['type' => 'bool'],
-        'tracing_sample_rate'          => ['type' => 'float'],
+        'tracing_sample_rate'          => ['type' => 'float'], /* @deprecated by @see: traces_sample_rate https://docs.sentry.io/platforms/php/configuration/options/#error_types */
         'performance_tracking_enabled' => ['type' => 'bool'],
         'performance_tracking_excluded_areas' => ['type' => 'array'],
         'ignore_js_errors'             => ['type' => 'array'],
@@ -116,16 +117,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Get sample rate for php profiling.
-     *
-     * @return float
-     */
-    public function getPhpProfileSampleRate(): float
-    {
-        return (float) ($this->collectModuleConfig()['profiles_sample_rate'] ?? 0);
-    }
-
-    /**
      * Whether tracing is enabled.
      */
     public function isTracingEnabled(): bool
@@ -138,7 +129,7 @@ class Data extends AbstractHelper
      */
     public function getTracingSampleRate(): float
     {
-        return (float) ($this->collectModuleConfig()['tracing_sample_rate'] ?? 0.2);
+        return (float) ($this->collectModuleConfig()['traces_sample_rate'] ?? $this->collectModuleConfig()['tracing_sample_rate'] ?? 0.2);
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -25,6 +25,32 @@ class Data extends AbstractHelper
     public const XML_PATH_SRS = 'sentry/general/';
     public const XML_PATH_SRS_ISSUE_GROUPING = 'sentry/issue_grouping/';
 
+    public const NATIVE_SENTRY_CONFIG_KEYS = [
+        // https://docs.sentry.io/platforms/php/configuration/options/#core-options
+        'dsn' => ['type' => 'string'],
+        'max_breadcrumbs' => ['type' => 'int'],
+        'attach_stacktrace' => ['type' => 'bool'],
+        'send_default_pii' => ['type' => 'bool'],
+        'server_name' => ['type' => 'string'],
+        'in_app_include' => ['type' => 'array'],
+        'in_app_exclude' => ['type' => 'array'],
+        'max_request_body_size' => ['type' => 'string'],
+        'max_value_length' => ['type' => 'int'],
+        // https://docs.sentry.io/platforms/php/configuration/options/#error-monitoring-options
+        'sample_rate' => ['type' => 'float'],
+        'ignore_exceptions' => ['type' => 'array'],
+        'error_types' => ['type' => 'int'],
+        'context_lines' => ['type' => 'int'],
+        // https://docs.sentry.io/platforms/php/configuration/options/#tracing-options
+        'traces_sample_rate' => ['type' => 'float'],
+        'ignore_transactions' => ['type' => 'array'],
+        'trace_propagation_targets' => ['type' => 'array'],
+        // https://docs.sentry.io/platforms/php/configuration/options/#transport-options
+        'http_proxy' => ['type' => 'string'],
+        'http_connect_timeout' => ['type' => 'int'],
+        'http_timeout' => ['type' => 'int'],
+    ];
+
     /**
      * @var ScopeConfigInterface
      */
@@ -39,19 +65,18 @@ class Data extends AbstractHelper
      * @var array
      */
     protected $configKeys = [
-        'dsn',
-        'logrocket_key',
-        'log_level',
-        'errorexception_reporting',
-        'ignore_exceptions',
-        'mage_mode_development',
-        'environment',
-        'js_sdk_version',
-        'tracing_enabled',
-        'tracing_sample_rate',
-        'ignore_js_errors',
-        'disable_default_integrations',
-        'clean_stacktrace',
+        ...self::NATIVE_SENTRY_CONFIG_KEYS,
+        'logrocket_key' => ['type' => 'array'],
+        'log_level' => ['type' => 'int'],
+        'errorexception_reporting' => ['type' => 'int'], // Deprecated by error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types
+        'mage_mode_development' => ['type' => 'bool'],
+        'environment' => ['type' => 'string'],
+        'js_sdk_version' => ['type' => 'string'],
+        'tracing_enabled' => ['type' => 'bool'],
+        'tracing_sample_rate' => ['type' => 'float'],
+        'ignore_js_errors' => ['type' => 'array'],
+        'disable_default_integrations' => ['type' => 'array'],
+        'clean_stacktrace' => ['type' => 'bool'],
     ];
 
     /**
@@ -119,25 +144,7 @@ class Data extends AbstractHelper
      */
     public function getIgnoreJsErrors()
     {
-        $list = $this->collectModuleConfig()['ignore_js_errors'];
-
-        if ($list === null) {
-            return null;
-        }
-
-        try {
-            $config = $this->collectModuleConfig();
-            $list = is_array($config['ignore_js_errors'])
-                ? $config['ignore_js_errors']
-                : $this->serializer->unserialize($config['ignore_js_errors']);
-        } catch (InvalidArgumentException $e) {
-            throw new RuntimeException(
-                __('Sentry configuration error: `ignore_js_errors` has to be an array or `null`. Given type: %s', gettype($list)), // phpcs:ignore
-                $e
-            );
-        }
-
-        return $list;
+        return $this->collectModuleConfig()['ignore_js_errors'];
     }
 
     /**
@@ -216,19 +223,43 @@ class Data extends AbstractHelper
             $this->config[$storeId]['enabled'] = $this->scopeConfig->getValue('sentry/environment/enabled', ScopeInterface::SCOPE_STORE)
                 ?? $this->deploymentConfig->get('sentry') !== null;
         } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
-            $this->config[$storeId]['enabled'] = null;
+            $this->config[$storeId]['enabled'] = $this->deploymentConfig->get('sentry') !== null;
         }
 
-        foreach ($this->configKeys as $value) {
+        foreach ($this->configKeys as $value => $config) {
             try {
-                $this->config[$storeId][$value] = $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
-                    ?? $this->deploymentConfig->get('sentry/'.$value);
+                $this->config[$storeId][$value] = $this->processConfigValue(
+                    $this->scopeConfig->getValue('sentry/environment/'.$value, ScopeInterface::SCOPE_STORE)
+                        ?? $this->deploymentConfig->get('sentry/'.$value),
+                    $config
+                );
             } catch (TableNotFoundException|FileSystemException|RuntimeException $e) {
                 $this->config[$storeId][$value] = null;
             }
         }
 
         return $this->config[$storeId];
+    }
+
+    /**
+     * Parse the config value to the type defined in the config
+     *
+     * @param mixed $value
+     * @param array{type: string} $config
+     */
+    public function processConfigValue(mixed $value, array $config): mixed {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return match ($config['type']) {
+            'array' => is_array($value) ? $value : $this->serializer->unserialize($value),
+            'int' => (int) $value,
+            'float' => (float) $value,
+            'bool' => (bool) $value,
+            'string' => (string) $value,
+            default => $value,
+        };
     }
 
     /**
@@ -477,9 +508,9 @@ class Data extends AbstractHelper
      *
      * @return int
      */
-    public function getErrorExceptionReporting(): int
+    public function getErrorTypes(): int
     {
-        return (int) ($this->collectModuleConfig()['errorexception_reporting'] ?? error_reporting());
+        return (int) ($this->collectModuleConfig()['error_types'] ?? $this->collectModuleConfig()['errorexception_reporting'] ?? error_reporting());
     }
 
     /**
@@ -489,16 +520,7 @@ class Data extends AbstractHelper
      */
     public function getIgnoreExceptions(): array
     {
-        $config = $this->collectModuleConfig();
-        if (is_array($config['ignore_exceptions'])) {
-            return $config['ignore_exceptions'];
-        }
-
-        try {
-            return $this->serializer->unserialize($config['ignore_exceptions']);
-        } catch (InvalidArgumentException $e) {
-            return [];
-        }
+        return $this->collectModuleConfig()['ignore_exceptions'] ?? [];
     }
 
     /**
@@ -510,7 +532,7 @@ class Data extends AbstractHelper
      */
     public function shouldCaptureException(Throwable $ex): bool
     {
-        if ($ex instanceof ErrorException && !($ex->getSeverity() & $this->getErrorExceptionReporting())) {
+        if ($ex instanceof ErrorException && !($ex->getSeverity() & $this->getErrorTypes())) {
             return false;
         }
 

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -53,7 +53,7 @@ class GlobalExceptionCatcher
 
         /** @var DataObject $config */
         $config = $this->dataObjectFactory->create();
-        $config->setData(array_filter(array_intersect_key($this->sentryHelper->collectModuleConfig(), SenteryHelper::NATIVE_SENTRY_CONFIG_KEYS)));
+        $config->setData(array_intersect_key($this->sentryHelper->collectModuleConfig(), SenteryHelper::NATIVE_SENTRY_CONFIG_KEYS));
 
         $config->setDsn($this->sentryHelper->getDSN());
         if ($release = $this->releaseIdentifier->getReleaseId()) {
@@ -85,17 +85,15 @@ class GlobalExceptionCatcher
 
         if ($this->sentryHelper->isPerformanceTrackingEnabled()) {
             $config->setTracesSampleRate($this->sentryHelper->getTracingSampleRate());
-        }
-
-        if ($rate = $this->sentryHelper->getPhpProfileSampleRate()) {
-            $config->setData('profiles_sample_rate', $rate);
+        } else {
+            $config->unsetTracesSampleRate(null);
         }
 
         $this->eventManager->dispatch('sentry_before_init', [
             'config' => $config,
         ]);
 
-        $this->sentryInteraction->initialize($config->getData());
+        $this->sentryInteraction->initialize(array_filter($config->getData()));
         $this->sentryPerformance->startTransaction($subject);
 
         try {

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -53,7 +53,7 @@ class GlobalExceptionCatcher
 
         /** @var DataObject $config */
         $config = $this->dataObjectFactory->create();
-        $config->setData(array_intersect_key($this->sentryHelper->collectModuleConfig(), SenteryHelper::NATIVE_SENTRY_CONFIG_KEYS));
+        $config->setData(array_intersect_key($this->sentryHelper->collectModuleConfig(), SentryHelper::NATIVE_SENTRY_CONFIG_KEYS));
 
         $config->setDsn($this->sentryHelper->getDSN());
         if ($release = $this->releaseIdentifier->getReleaseId()) {

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -49,6 +49,7 @@ class GlobalExceptionCatcher
 
         /** @var DataObject $config */
         $config = $this->dataObjectFactory->create();
+        $config->setData(array_filter(array_intersect_key($this->sentryHelper->collectModuleConfig(), SenteryHelper::NATIVE_SENTRY_CONFIG_KEYS)));
 
         $config->setDsn($this->sentryHelper->getDSN());
         if ($release = $this->releaseIdentifier->getReleaseId()) {
@@ -76,8 +77,7 @@ class GlobalExceptionCatcher
             static fn (IntegrationInterface $integration) => !in_array(get_class($integration), $disabledDefaultIntegrations)
         ));
 
-        $config->setIgnoreExceptions($this->sentryHelper->getIgnoreExceptions());
-        $config->setErrorTypes($this->sentryHelper->getErrorExceptionReporting());
+        $config->setErrorTypes($this->sentryHelper->getErrorTypes());
 
         $this->eventManager->dispatch('sentry_before_init', [
             'config' => $config,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'mage_mode_development' => false,
     'js_sdk_version' => \JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION,
     'tracing_enabled' => true,
-    'tracing_sample_rate' => 0.5,
+    'traces_sample_rate' => 0.5,
     'disable_default_integrations' => [
         \Sentry\Integration\ModulesIntegration::class,
     ]
@@ -70,7 +70,7 @@ Next to that there are some configuration options under Stores > Configuration >
 | `mage_mode_development`     | `false` | If set to true, you will receive issues in Sentry even if Magento is running in develop mode. |
 | `js_sdk_version`            | `\JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION` | If set, loads the explicit version of the JavaScript SDK of Sentry. |
 | `tracing_enabled`           | `false` | If set to true, tracing is enabled (bundle file is loaded automatically). |
-| `tracing_sample_rate`       | `0.2` | If tracing is enabled, set the sample rate. |
+| `traces_sample_rate`        | `0.2` | If tracing is enabled, set the sample rate. |
 | `performance_tracking_enabled` | `false` | if performance tracking is enabled, a performance report got generated for the request. |
 | `performance_tracking_excluded_areas` | `['adminhtml', 'crontab']` | if `performance_tracking_enabled` is enabled, we recommend to exclude the `adminhtml` & `crontab` area. |
 | `profiles_sample_rate` | `0` (disabled) | if this option is larger than 0 (zero), the module will create a profile of the request. Please note that you have to install [Excimer](https://www.mediawiki.org/wiki/Excimer) on your server to use profiling. [Sentry documentation](https://docs.sentry.io/platforms/php/profiling/). You have to enable tracing too. |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ public function execute(\Magento\Framework\Event\Observer $observer)
 
 Example: https://github.com/justbetter/magento2-sentry-filter-events
 
+This same thing is the case for
+| sentry_before_send | https://docs.sentry.io/platforms/php/configuration/options/#before_send |
+| sentry_before_send_transaction | https://docs.sentry.io/platforms/php/configuration/options/#before_send_transaction |
+| sentry_before_send_check_in | https://docs.sentry.io/platforms/php/configuration/options/#before_send_check_in |
+| sentry_before_breadcrumb | https://docs.sentry.io/platforms/php/configuration/options/#before_breadcrumb |
+
 ## Compatibility
 The module is tested on Magento version 2.4.x with sentry sdk version 3.x. feel free to fork this project or make a pull request.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'logrocket_key' => 'example/example',
     'environment' => null,
     'log_level' => \Monolog\Logger::WARNING,
-    'errorexception_reporting' => E_ALL,
+    'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,
     'js_sdk_version' => \JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION,
@@ -61,7 +61,7 @@ Next to that there are some configuration options under Stores > Configuration >
 | `dsn`                       | — | The DSN you got from Sentry for your project. You can find the DSN in the project settings under "Client Key (DSN)" |
 | `environment`               | — | Specify the environment under which the deployed version is running. Common values: production, staging, development. Helps differentiate errors between environments. |
 | `log_level`                 | `\Monolog\Logger::WARNING` | Specify from which logging level on Sentry should get the messages. |
-| `errorexception_reporting`  | `E_ALL` | If the Exception is an instance of [ErrorException](https://www.php.net/manual/en/class.errorexception.php), send the error to Sentry if it matches the error reporting. Uses the same syntax as [Error Reporting](https://www.php.net/manual/en/function.error-reporting.php), e.g., `E_ERROR` | E_WARNING`. |
+| `error_types`  | `E_ALL` | If the Exception is an instance of [ErrorException](https://www.php.net/manual/en/class.errorexception.php), send the error to Sentry if it matches the error reporting. Uses the same syntax as [Error Reporting](https://www.php.net/manual/en/function.error-reporting.php), e.g., `E_ERROR` | E_WARNING`. |
 | `ignore_exceptions`         | `[]` | If the class being thrown matches any in this list, do not send it to Sentry, e.g., `[\Magento\Framework\Exception\NoSuchEntityException::class]` |
 | `clean_stacktrace`          | `true` | Whether unnecessary files (like Interceptor.php, Proxy.php, and Factory.php) should be removed from the stacktrace. (They will not be removed if they threw the error.) |
 | `mage_mode_development`     | `false` | If set to true, you will receive issues in Sentry even if Magento is running in develop mode. |
@@ -82,9 +82,9 @@ using the "Variables" in Adobe Commerce using the following variables:
 | `CONFIG__SENTRY__ENVIRONMENT__LOGROCKET_KEY`     | string  |
 | `CONFIG__SENTRY__ENVIRONMENT__ENVIRONMENT`       | string  |
 | `CONFIG__SENTRY__ENVIRONMENT__LOG_LEVEL`         | integer |
-| `CONFIG__SENTRY__ENVIRONMENT__ERROREXCEPTION_REPORTING` | integer |
+| `CONFIG__SENTRY__ENVIRONMENT__ERROR_TYPES`       | integer |
 | `CONFIG__SENTRY__ENVIRONMENT__IGNORE_EXCEPTIONS` | JSON array of classes |
-| `CONFIG__SENTRY__ENVIRONMENT__CLEAN_STACKTRACE` | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__CLEAN_STACKTRACE`  | boolean |
 | `CONFIG__SENTRY__ENVIRONMENT__MAGE_MODE_DEVELOPMENT` | string  |
 | `CONFIG__SENTRY__ENVIRONMENT__JS_SDK_VERSION`    | string  |
 | `CONFIG__SENTRY__ENVIRONMENT__TRACING_ENABLED`   | boolean |

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "Performance"
   ],
   "type": "magento2-module",
-  "version": "4.1.0",
   "license": "MIT",
   "require": {
     "php": ">=8.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "Performance"
   ],
   "type": "magento2-module",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "license": "MIT",
   "require": {
     "php": ">=8.0",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -125,7 +125,7 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="tracing_sample_rate" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
+                <field id="traces_sample_rate" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Tracing Sample Rate</label>
                     <validate>validate-not-negative-number validate-number</validate>
                     <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,7 +18,7 @@
                 <logrocket_key/>
                 <environment/>
                 <log_level/>
-                <errorexception_reporting/>
+                <error_types/>
                 <ignore_exceptions/>
                 <mage_mode_development/>
                 <js_sdk_version/>

--- a/view/adminhtml/templates/system/config/deployment-config-info.phtml
+++ b/view/adminhtml/templates/system/config/deployment-config-info.phtml
@@ -21,7 +21,7 @@
     'logrocket_key' => 'example/example',
     'environment' => null,
     'log_level' => \Monolog\Logger::WARNING,
-    'errorexception_reporting' => E_ALL,
+    'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,
 ]"); ?>


### PR DESCRIPTION
**Summary**

This PR adds the additional Sentry config options (https://docs.sentry.io/platforms/php/configuration/options/) to the configuration.

It has also overhauled the config processing, now automatically parsing env variables to an array for array types.

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`