### PR TITLE
Add sentry logger by hooking into monolog setHandlers

### DIFF
--- a/Controller/Adminhtml/Test/Sentry.php
+++ b/Controller/Adminhtml/Test/Sentry.php
@@ -3,7 +3,7 @@
 namespace JustBetter\Sentry\Controller\Adminhtml\Test;
 
 use JustBetter\Sentry\Helper\Data;
-use JustBetter\Sentry\Plugin\MonologPlugin;
+use Magento\Framework\Logger\Monolog;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Serialize\Serializer\Json;
@@ -27,7 +27,7 @@ class Sentry extends Action
      * @param Json            $jsonSerializer
      * @param LoggerInterface $logger
      * @param Data            $helperSentry
-     * @param MonologPlugin   $monologPlugin
+     * @param Monolog         $monolog
      */
     public function __construct(
         Context $context,
@@ -35,7 +35,7 @@ class Sentry extends Action
         private Json $jsonSerializer,
         protected LoggerInterface $logger,
         private Data $helperSentry,
-        private MonologPlugin $monologPlugin
+        private Monolog $monolog
     ) {
         parent::__construct($context);
     }
@@ -54,7 +54,7 @@ class Sentry extends Action
         if ($activeWithReason['active']) {
             try {
                 if ($this->helperSentry->isPhpTrackingEnabled()) {
-                    $this->monologPlugin->addRecord(\Monolog\Logger::ALERT, 'TEST message from Magento 2', []);
+                    $this->monolog->addRecord(\Monolog\Logger::ALERT, 'TEST message from Magento 2', []);
                     $result['status'] = true;
                     $result['content'] = __('Check sentry.io which should hold an alert');
                 } else {

--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -3,30 +3,52 @@
 namespace JustBetter\Sentry\Plugin;
 
 use JustBetter\Sentry\Logger\Handler\Sentry;
-use Magento\Framework\Logger\Monolog;
-use Monolog\LogRecord;
-use Monolog\Processor\ProcessorInterface;
+use Monolog\Logger;
 
-class MonologPlugin extends Monolog
+class MonologPlugin
 {
     /**
-     * @psalm-param array<callable(array): array> $processors
-     *
-     * @param string                              $name          The logging channel, a simple descriptive name that is attached to all log records
-     * @param Sentry                              $sentryHandler
-     * @param \Monolog\Handler\HandlerInterface[] $handlers      Optional stack of handlers, the first one in the array is called first, etc.
-     * @param callable[]                          $processors    Optional array of processors
-     *
-     * @phpstan-param array<(callable(LogRecord|array): LogRecord|array)|ProcessorInterface> $processors
+     * @param Sentry $sentryHandler The sentry handler we will add to all Monolog loggers.
      */
     public function __construct(
-        $name,
-        Sentry $sentryHandler,
-        array $handlers = [],
-        array $processors = []
+        protected Sentry $sentryHandler,
     ) {
-        $handlers['sentry'] = $sentryHandler;
+    }
 
-        parent::__construct($name, $handlers, $processors);
+    /**
+     * Add the Sentry handler to the Monolog logger if it does not already exist.
+     *
+     * @param Logger $subject
+     * @param array  $handlers
+     *
+     * @return array
+     */
+    public function beforeSetHandlers(
+        Logger $subject,
+        array $handlers
+    ): array {
+        if (!$this->containsHandler($handlers)) {
+            array_unshift($handlers, $this->sentryHandler);
+        }
+
+        return [$handlers];
+    }
+
+    /**
+     * Check if the Sentry handler is already in the list of handlers.
+     *
+     * @param array $handlers
+     *
+     * @return bool
+     */
+    public function containsHandler(array $handlers): bool
+    {
+        foreach ($handlers as $handler) {
+            if ($handler instanceof Sentry) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <!-- Cannot use plugin https://github.com/magento/magento2/issues/14950 -->
-    <preference for="Magento\Framework\Logger\Monolog" type="JustBetter\Sentry\Plugin\MonologPlugin"/>
+    <type name="Monolog\Logger">
+        <plugin disabled="false" name="SentryMonologPlugin" type="JustBetter\Sentry\Plugin\MonologPlugin" sortOrder="10"/>
+    </type>
+
+    <type name="JustBetter\Sentry\Plugin\MonologPlugin">
+        <arguments>
+            <argument name="sentryHandler" xsi:type="object">JustBetter\Sentry\Logger\Handler\Sentry\Proxy</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\AppInterface">
         <plugin disabled="false" name="GlobalExceptionCatcher" type="JustBetter\Sentry\Plugin\GlobalExceptionCatcher"
                 sortOrder="0"/>


### PR DESCRIPTION
**Summary**

closes: https://github.com/justbetter/magento2-sentry/issues/134

By plugging into monologs setHandlers method we can ensure sentry is added to ALL instances of monolog, including during crons, queues, and any custom loggers created by other modules.
setHandlers is also executed during the __construct function of monolog.

**Result**

Even crons and custom extension logs can be sent to Sentry if they match the log level

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`