### PR TITLE
Catch The default website isnt defined when getting store

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -2,6 +2,7 @@
 
 namespace JustBetter\Sentry\Helper;
 
+use DomainException;
 use ErrorException;
 use JustBetter\Sentry\Block\SentryScript;
 use Magento\Framework\App\Area;
@@ -13,6 +14,7 @@ use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\DB\Adapter\TableNotFoundException;
 use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
@@ -353,9 +355,14 @@ class Data extends AbstractHelper
     /**
      * Get the current store.
      */
-    public function getStore()
+    public function getStore(): ?\Magento\Store\Api\Data\StoreInterface
     {
-        return $this->storeManager->getStore();
+        try {
+            return $this->storeManager->getStore();
+        } catch (DomainException|NoSuchEntityException $e) {
+            // If the store is not available, return null
+            return null;
+        }
     }
 
     /**

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -137,9 +137,9 @@ class SentryLog
 
         $scope->setTag('mage_mode', $this->data->getAppState());
         $scope->setTag('version', $this->data->getMagentoVersion());
-        $scope->setTag('website_id', $store ? $store->getWebsiteId() : null);
-        $scope->setTag('store_id', $store ? $store->getStoreId() : null);
-        $scope->setTag('store_code', $store ? $store->getCode() : null);
+        $scope->setTag('website_id', (string) $store?->getWebsiteId());
+        $scope->setTag('store_id', (string) $store?->getId());
+        $scope->setTag('store_code', (string) $store?->getCode());
 
         if (false === empty($customTags)) {
             foreach ($customTags as $tag => $value) {


### PR DESCRIPTION
**Summary**

 closes: #160

With this PR we catch the exception thrown by Magento when no site exists.
This should ensure the sentry module doesn't interfere with setup:di:compile when env.php is missing or sites are missing due to another reason.

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`