### PR TITLE
Adjust the processConfigValue check for null, to check on empty instead

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -254,7 +254,7 @@ class Data extends AbstractHelper
      */
     public function processConfigValue(mixed $value, array $config): mixed
     {
-        if ($value === null) {
+        if (empty($value)) {
             return null;
         }
 


### PR DESCRIPTION
**Summary**

Adjust the processConfigValue check for null, to check on empty. Sometimes the value is false which causes the unserialize method to fail.

**Result**

If empty() evaluates the code will now return to prevent an exception from being triggered because serializer->unserialize() can't process false.

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`