### PR TITLE
Add the ability to select job codes using regex

### DIFF
--- a/Model/SentryCron.php
+++ b/Model/SentryCron.php
@@ -37,9 +37,15 @@ class SentryCron
     {
         if (!$this->data->isActive() ||
             !$this->data->isCronMonitoringEnabled() ||
-            !in_array(
-                $schedule->getJobCode(),
-                $this->data->getTrackCrons()
+            !array_reduce(
+                $this->data->getTrackCrons(), 
+                fn($trackCron, $expression) => 
+                    $trackCron || (
+                        preg_match('/^\/.*\/[imsu]*$/', $expression) ?
+                        preg_match($expression, $schedule->getJobCode()) :
+                        $schedule->getJobCode() === $expression
+                    ),
+                false
             )
         ) {
             return;


### PR DESCRIPTION
**Summary**

closes: #191

This PR adds the ability to track crons based on regex strings too, based on the matcher of https://github.com/getsentry/sentry-php/pull/1850/files#diff-40d7473316ef0bb3ba4c4d937b16ae3d1cc47e0d65815034ee2b5be6a74cb11eR41

this will make it possible to track crons by vendor `/justbetter_.+/` or all crons `/.*/` (if your limits allow enough check-ins)

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`