### PR TITLE
Added Logger support

### DIFF
--- a/Block/SentryScript.php
+++ b/Block/SentryScript.php
@@ -47,10 +47,6 @@ class SentryScript extends Template
             return true;
         }
 
-        if ($this->useSessionReplay()) {
-            return true;
-        }
-
         if ($this->isSpotlightEnabled()) {
             return true;
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,6 +37,7 @@ class Data extends AbstractHelper
         'server_name'           => ['type' => 'string'],
         'in_app_include'        => ['type' => 'array'],
         'in_app_exclude'        => ['type' => 'array'],
+        'prefixes'              => ['type' => 'array'],
         'max_request_body_size' => ['type' => 'string'],
         'max_value_length'      => ['type' => 'int'],
         // https://docs.sentry.io/platforms/php/configuration/options/#error-monitoring-options
@@ -50,6 +51,8 @@ class Data extends AbstractHelper
         'trace_propagation_targets' => ['type' => 'array'],
         // https://docs.sentry.io/platforms/php/profiling/#enabling-profiling
         'profiles_sample_rate'      => ['type' => 'float'],
+        // https://docs.sentry.io/platforms/php/configuration/options/#logs-options
+        'enable_logs'               => ['type' => 'bool'],
         // https://docs.sentry.io/platforms/php/configuration/options/#transport-options
         'http_proxy'           => ['type' => 'string'],
         'http_connect_timeout' => ['type' => 'int'],
@@ -76,6 +79,7 @@ class Data extends AbstractHelper
         ...self::NATIVE_SENTRY_CONFIG_KEYS,
         'logrocket_key'                       => ['type' => 'string'],
         'log_level'                           => ['type' => 'int'],
+        'logger_log_level'                    => ['type' => 'int', 'default' => \Monolog\Logger::DEBUG],
         'errorexception_reporting'            => ['type' => 'int'], /* @deprecated by @see: error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types */
         'mage_mode_development'               => ['type' => 'bool'],
         'js_sdk_version'                      => ['type' => 'string'],
@@ -291,7 +295,7 @@ class Data extends AbstractHelper
     public function processConfigValue(mixed $value, array $config): mixed
     {
         if ($value === null) {
-            return null;
+            return $config['default'] ?? null;
         }
 
         return match ($config['type']) {

--- a/Model/Collector/SentryRelatedCspCollector.php
+++ b/Model/Collector/SentryRelatedCspCollector.php
@@ -26,7 +26,7 @@ class SentryRelatedCspCollector implements PolicyCollectorInterface
             return $policies;
         }
 
-        if ($this->dataHelper->useScriptTag() || $this->dataHelper->useSessionReplay()) {
+        if ($this->dataHelper->useScriptTag()) {
             $policies[] = new FetchPolicy(
                 'script-src',
                 false,

--- a/Model/SentryCron.php
+++ b/Model/SentryCron.php
@@ -33,7 +33,7 @@ class SentryCron
      *
      * @param Schedule $schedule
      */
-    public function sendScheduleStatus(Schedule $schedule)
+    public function sendScheduleStatus(Schedule $schedule): void
     {
         if (!$this->data->isActive() ||
             !$this->data->isCronMonitoringEnabled() ||
@@ -84,7 +84,7 @@ class SentryCron
      * @param Schedule           $schedule
      * @param MonitorConfig|null $monitorConfig
      */
-    public function startCheckin(Schedule $schedule, ?MonitorConfig $monitorConfig = null)
+    public function startCheckin(Schedule $schedule, ?MonitorConfig $monitorConfig = null): void
     {
         $this->runningCheckins[$schedule->getId()] = [
             'started_at'  => microtime(true),
@@ -102,7 +102,7 @@ class SentryCron
      * @param Schedule           $schedule
      * @param MonitorConfig|null $monitorConfig
      */
-    public function finishCheckin(Schedule $schedule, ?MonitorConfig $monitorConfig = null)
+    public function finishCheckin(Schedule $schedule, ?MonitorConfig $monitorConfig = null): void
     {
         if (!isset($this->runningCheckins[$schedule->getId()])) {
             return;

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -8,6 +8,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\SessionException;
+use Magento\Framework\Logger\Monolog;
 use Sentry\EventHint;
 use Sentry\ExceptionMechanism;
 use Sentry\Stacktrace;
@@ -43,10 +44,21 @@ class SentryLog
      * @param int               $logLevel
      * @param array             $context
      */
-    public function send($message, $logLevel, $context = [])
+    public function send($message, $logLevel, $context = []): void
     {
         $config = $this->data->collectModuleConfig();
         $customTags = [];
+
+        if ($config['enable_logs'] && $logLevel >= $config['logger_log_level']) {
+            match ($logLevel) {
+                Monolog::DEBUG => \Sentry\Logger()->debug($message, $context),
+                Monolog::INFO => \Sentry\Logger()->info($message, $context),
+                Monolog::WARNING => \Sentry\Logger()->warn($message, $context),
+                Monolog::ERROR, MONOLOG::CRITICAL => \Sentry\Logger()->error($message, $context),
+                Monolog::ALERT, MONOLOG::EMERGENCY => \Sentry\Logger()->fatal($message, $context),
+                default => \Sentry\Logger()->info($message, $context)
+            };
+        }
 
         if ($logLevel < (int) $config['log_level']) {
             return;
@@ -146,5 +158,13 @@ class SentryLog
                 $scope->setTag($tag, $value);
             }
         }
+    }
+
+    /**
+     * Send the logs to Sentry if there are any.
+     */
+    public function __destruct()
+    {
+        \Sentry\Logger()->flush();
     }
 }

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -170,6 +170,16 @@ class GlobalExceptionCatcher
             return $data->getCheckIn();
         });
 
+        $config->setBeforeSendLog(function (\Sentry\Logs\Log $log): ?\Sentry\Logs\Log {
+            $data = $this->dataObjectFactory->create();
+            $data->setLog($log);
+            $this->eventManager->dispatch('sentry_before_send_log', [
+                'sentry_log' => $data,
+            ]);
+
+            return $data->getLog();
+        });
+
         $config->setBeforeSend(function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
             $data = $this->dataObjectFactory->create();
             $data->setEvent($event);

--- a/Plugin/SampleRequest.php
+++ b/Plugin/SampleRequest.php
@@ -26,7 +26,7 @@ class SampleRequest
      *
      * @param ResponseInterface $response
      */
-    public function beforeSendResponse(ResponseInterface $response)
+    public function beforeSendResponse(ResponseInterface $response): void
     {
         $this->sentryPerformance->finishTransaction($response);
     }

--- a/README.md
+++ b/README.md
@@ -64,24 +64,31 @@ Next to that there are some configuration options under Stores > Configuration >
 | Name | Default | Description |
 |---|---|---|
 | `dsn`                       | — | The DSN you got from Sentry for your project. You can find the DSN in the project settings under "Client Key (DSN)" |
-| `environment`               | — | Specify the environment under which the deployed version is running. Common values: production, staging, development. Helps differentiate errors between environments. |
-| `log_level`                 | `\Monolog\Logger::WARNING` | Specify from which logging level on Sentry should get the messages. |
-| `error_types`  | `E_ALL` | If the Exception is an instance of [ErrorException](https://www.php.net/manual/en/class.errorexception.php), send the error to Sentry if it matches the error reporting. Uses the same syntax as [Error Reporting](https://www.php.net/manual/en/function.error-reporting.php), e.g., `E_ERROR` | E_WARNING`. |
-| `ignore_exceptions`         | `[]` | If the class being thrown matches any in this list, do not send it to Sentry, e.g., `[\Magento\Framework\Exception\NoSuchEntityException::class]` |
-| `clean_stacktrace`          | `true` | Whether unnecessary files (like Interceptor.php, Proxy.php, and Factory.php) should be removed from the stacktrace. (They will not be removed if they threw the error.) |
 | `mage_mode_development`     | `false` | If set to true, you will receive issues in Sentry even if Magento is running in develop mode. |
-| `js_sdk_version`            | `\JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION` | If set, loads the explicit version of the JavaScript SDK of Sentry. |
+| `environment`               | — | Specify the environment under which the deployed version is running. Common values: production, staging, development. Helps differentiate errors between environments. |
+| `max_breadcrumbs`           | `100` | This variable controls the total amount of breadcrumbs that should be captured. |
+| `attach_stacktrace`         | `false` | When enabled, stack traces are automatically attached to all messages logged. Even if they are not exceptions. |
+| `prefixes`                  | - | A list of prefixes that should be stripped from the filenames of captured stacktraces to make them relative. |
+| `sample_rate`               | `1.0` | Configures the sample rate for error events, in the range of 0.0 to 1.0. |
+| `ignore_exceptions`         | `[]` | If the class being thrown matches any in this list, do not send it to Sentry, e.g., `[\Magento\Framework\Exception\NoSuchEntityException::class]` |
+| `error_types`               | `E_ALL` | If the Exception is an instance of [ErrorException](https://www.php.net/manual/en/class.errorexception.php), send the error to Sentry if it matches the error reporting. Uses the same syntax as [Error Reporting](https://www.php.net/manual/en/function.error-reporting.php), e.g., `E_ERROR` | E_WARNING`. |
+| `log_level`                 | `\Monolog\Logger::WARNING` | Specify from which logging level on Sentry should get the [messages](https://docs.sentry.io/platforms/php/usage/#capturing-messages). |
+| `clean_stacktrace`          | `true` | Whether unnecessary files (like Interceptor.php, Proxy.php, and Factory.php) should be removed from the stacktrace. (They will not be removed if they threw the error.) |
 | `tracing_enabled`           | `false` | If set to true, tracing is enabled (bundle file is loaded automatically). |
-| `traces_sample_rate`        | `0.2` | If tracing is enabled, set the sample rate. |
-| `performance_tracking_enabled` | `false` | if performance tracking is enabled, a performance report got generated for the request. |
+| `traces_sample_rate`        | `0.2` | If tracing is enabled, set the sample rate. A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. |
+| `profiles_sample_rate`      | `0` (disabled) | if this option is larger than 0 (zero), the module will create a profile of the request. Please note that you have to install [Excimer](https://www.mediawiki.org/wiki/Excimer) on your server to use profiling. [Sentry documentation](https://docs.sentry.io/platforms/php/profiling/). You have to enable tracing too. |
+| `performance_tracking_enabled` | `false` | if performance tracking is enabled, a performance report gets generated for the request. |
 | `performance_tracking_excluded_areas` | `['adminhtml', 'crontab']` | if `performance_tracking_enabled` is enabled, we recommend to exclude the `adminhtml` & `crontab` area. |
-| `profiles_sample_rate` | `0` (disabled) | if this option is larger than 0 (zero), the module will create a profile of the request. Please note that you have to install [Excimer](https://www.mediawiki.org/wiki/Excimer) on your server to use profiling. [Sentry documentation](https://docs.sentry.io/platforms/php/profiling/). You have to enable tracing too. |
+| `enable_logs`               | `false` | This option enables the [logging integration](https://sentry.io/product/logs/), which allows the SDK to capture logs and send them to Sentry. |
+| `logger_log_level`          | `\Monolog\Logger::NOTICE` | If the logging integration is enabled, specify from which logging level the logger should log |
+| `js_sdk_version`            | `\JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION` | If set, loads the explicit version of the JavaScript SDK of Sentry. |
 | `ignore_js_errors`          | `[]` | Array of JavaScript error messages which should not be sent to Sentry. (See also `ignoreErrors` in [Sentry documentation](https://docs.sentry.io/clients/javascript/config/)) |
 | `disable_default_integrations` | `[]` | Provide a list of FQCN of default integrations you do not want to use. [List of default integrations](https://github.com/getsentry/sentry-php/tree/master/src/Integration).|
 | `cron_monitoring_enabled` | `false` | Wether to enable [cron check ins](https://docs.sentry.io/platforms/php/crons/#upserting-cron-monitors) |
 | `track_crons` | `[]` | Cron handles of crons to track with cron monitoring, [Sentry only supports 6 check-ins per minute](https://docs.sentry.io/platforms/php/crons/#rate-limits) Magento does many more. |
 | `spotlight` | `false` | Enable [Spotlight](https://spotlightjs.com/) on the page |
-| `spotlight_url` | - | Override the [Sidecar url](https://spotlightjs.com/sidecar/) |
+| `spotlight_url` | - | Override the [Sidecar url](https://spotlightjs.com/sidecar/) |         
+                   
 
 ### Configuration for Adobe Cloud
 Since Adobe Cloud doesn't allow you to add manually add content to the `env.php` file, the configuration can be done
@@ -91,18 +98,23 @@ using the "Variables" in Adobe Commerce using the following variables:
 |--------------------------------------------------|---------|
 | `CONFIG__SENTRY__ENVIRONMENT__ENABLED`           | boolean |
 | `CONFIG__SENTRY__ENVIRONMENT__DSN`               | string  |
-| `CONFIG__SENTRY__ENVIRONMENT__LOGROCKET_KEY`     | string  |
-| `CONFIG__SENTRY__ENVIRONMENT__ENVIRONMENT`       | string  |
-| `CONFIG__SENTRY__ENVIRONMENT__LOG_LEVEL`         | integer |
-| `CONFIG__SENTRY__ENVIRONMENT__ERROR_TYPES`       | integer |
-| `CONFIG__SENTRY__ENVIRONMENT__IGNORE_EXCEPTIONS` | JSON array of classes |
-| `CONFIG__SENTRY__ENVIRONMENT__CLEAN_STACKTRACE`  | boolean |
 | `CONFIG__SENTRY__ENVIRONMENT__MAGE_MODE_DEVELOPMENT` | string  |
-| `CONFIG__SENTRY__ENVIRONMENT__JS_SDK_VERSION`    | string  |
+| `CONFIG__SENTRY__ENVIRONMENT__ENVIRONMENT`       | string  |
+| `CONFIG__SENTRY__ENVIRONMENT__MAX_BREADCRUMBS`   | integer  |
+| `CONFIG__SENTRY__ENVIRONMENT__ATTACH_STACKTRACE` | boolean  |
+| `CONFIG__SENTRY__ENVIRONMENT__SAMPLE_RATE`       | float  |
+| `CONFIG__SENTRY__ENVIRONMENT__IGNORE_EXCEPTIONS` | JSON array of classes |
+| `CONFIG__SENTRY__ENVIRONMENT__ERROR_TYPES`       | integer |
+| `CONFIG__SENTRY__ENVIRONMENT__LOG_LEVEL`         | integer |
+| `CONFIG__SENTRY__ENVIRONMENT__CLEAN_STACKTRACE`  | boolean |
 | `CONFIG__SENTRY__ENVIRONMENT__TRACING_ENABLED`   | boolean |
-| `CONFIG__SENTRY__ENVIRONMENT__TRACING_SAMPLE_RATE` | float   |
-| `CONFIG__SENTRY__ENVIRONMENT__TRACING_PERFORMANCE_TRACKING_ENABLED` | boolean |
-| `CONFIG__SENTRY__ENVIRONMENT__TRACING_PERFORMANCE_TRACKING_EXCLUDED_AREAS` | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__TRACES_SAMPLE_RATE`| float |
+| `CONFIG__SENTRY__ENVIRONMENT__PROFILES_SAMPLE_RATE`| float |
+| `CONFIG__SENTRY__ENVIRONMENT__PERFORMANCE_TRACKING_ENABLED` | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__PERFORMANCE_TRACKING_EXCLUDED_AREAS` | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__ENABLE_LOGS`       | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__LOGGER_LOG_LEVEL`  | boolean |
+| `CONFIG__SENTRY__ENVIRONMENT__JS_SDK_VERSION`    | string  |
 | `CONFIG__SENTRY__ENVIRONMENT__IGNORE_JS_ERRORS`  | JSON array of error messages |
 
 The following configuration settings can be overridden in the Magento admin. This is limited to ensure that changes to
@@ -135,9 +147,10 @@ This same thing is the case for
 | sentry_before_send_transaction | https://docs.sentry.io/platforms/php/configuration/options/#before_send_transaction |
 | sentry_before_send_check_in    | https://docs.sentry.io/platforms/php/configuration/options/#before_send_check_in    |
 | sentry_before_breadcrumb       | https://docs.sentry.io/platforms/php/configuration/options/#before_breadcrumb       |
+| sentry_before_send_log         | https://docs.sentry.io/platforms/php/configuration/options/#before_send_log         |
 
 ## Compatibility
-The module is tested on Magento version 2.4.x with sentry sdk version 3.x. feel free to fork this project or make a pull request.
+The module is tested on Magento version 2.4.x with sentry sdk version 4.x. feel free to fork this project or make a pull request.
 
 ## Ideas, bugs or suggestions?
 Please create a [issue](https://github.com/justbetter/magento2-sentry/issues) or a [pull request](https://github.com/justbetter/magento2-sentry/pulls).

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "require": {
     "php": ">=8.0",
-    "sentry/sentry": "^4.4",
+    "sentry/sentry": "^4.13",
     "monolog/monolog": ">=2.7.0|^3.0",
     "magento/framework": ">=103.0.7",
     "magento/module-csp": "*",
@@ -79,7 +79,6 @@
   },
   "require-dev": {
     "bitexpert/phpstan-magento": "^0.32.0",
-    "magento/magento-coding-standard": "^34",
-    "phpstan/phpstan": "^1.12"
+    "magento/magento-coding-standard": "^34"
   }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,7 +19,7 @@
                     <label>Enable PHP Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_performance_tracking" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="performance_tracking_enabled" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable Performance Tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
@@ -37,6 +37,9 @@
                 <field id="enable_session_replay" translate="label" type="select" sortOrder="40" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Enable Session Replay</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enable_script_tag">1</field>
+                    </depends>
                 </field>
                 <field id="replay_session_sample_rate" translate="label" type="text" sortOrder="50" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Session Sample Rate</label>
@@ -80,7 +83,7 @@
                         <field id="use_logrocket">1</field>
                     </depends>
                 </field>
-                <field id="sent_sentry" translate="label" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="send_sentry_test" translate="label" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <button_label>Send Sentry test event</button_label>
                     <button_url>justbetter_sentry/test/sentry</button_url>
                     <frontend_model>JustBetter\Sentry\Block\Adminhtml\System\Config\Button</frontend_model>
@@ -118,7 +121,7 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
-                <field id="tracing_enabled" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
+                <field id="tracing_enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Tracing Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
         <sentry>
             <general>
                 <enable_php_tracking>1</enable_php_tracking>
-                <enable_performance_tracking>0</enable_performance_tracking>
+                <performance_tracking_enabled>0</performance_tracking_enabled>
                 <enable_script_tag>0</enable_script_tag>
                 <script_tag_placement>before.body.end</script_tag_placement>
                 <use_logrocket>0</use_logrocket>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,7 @@ parameters:
         - vendor
         - Test/*
         - Logger/Handler/Sentry.php
-    level: 5
+    level: 6
+    ignoreErrors:
+        -
+            identifier: missingType.iterableValue


### PR DESCRIPTION
**Summary**

This PR adds support for the https://docs.sentry.io/platforms/php/logs/ integration from Sentry. Allowing actual logs to be centrally managed and linked to errors

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`