### PR TITLE
Added custom SDK identifier to module

### DIFF
--- a/Model/SentryInteraction.php
+++ b/Model/SentryInteraction.php
@@ -6,8 +6,6 @@ namespace JustBetter\Sentry\Model;
 
 // phpcs:disable Magento2.Functions.DiscouragedFunction
 
-use function Sentry\captureException;
-use function Sentry\configureScope;
 use JustBetter\Sentry\Helper\Data;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\Model\Auth\Session as AdminSession;
@@ -17,12 +15,14 @@ use Magento\Framework\App\State;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Framework\ObjectManager\ConfigInterface;
-
 use ReflectionClass;
 use Sentry\ClientBuilder;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Throwable;
+
+use function Sentry\captureException;
+use function Sentry\configureScope;
 
 class SentryInteraction
 {


### PR DESCRIPTION
**Summary**

This Pr adds a custom SDK identifier to the Sentry instance in the same way as the Laravel integration does it.

**Result**

This makes it easier to filter through issues, spans, etc. As you can filter specifically for Magento events now:
<img width="257" height="33" alt="image" src="https://github.com/user-attachments/assets/09ca2a4e-abc9-4cd5-8454-c2565aca3276" />
This would also allow filtering for named php errors only:
<img width="201" height="34" alt="image" src="https://github.com/user-attachments/assets/76fa84b2-55a1-49ec-b062-d039ce1d7684" />


**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`