### PR TITLE
fix: :bug: fixes #213 by replacing \Monolog\Logger with \Monolog\Level

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -80,7 +80,7 @@ class Data extends AbstractHelper
         ...self::NATIVE_SENTRY_CONFIG_KEYS,
         'logrocket_key'                       => ['type' => 'string'],
         'log_level'                           => ['type' => 'int'],
-        'logger_log_level'                    => ['type' => 'int', 'default' => \Monolog\Logger::WARNING],
+        'logger_log_level'                    => ['type' => 'int', 'default' => \Monolog\Level::Warning],
         'errorexception_reporting'            => ['type' => 'int'], /* @deprecated by @see: error_types https://docs.sentry.io/platforms/php/configuration/options/#error_types */
         'mage_mode_development'               => ['type' => 'bool'],
         'js_sdk_version'                      => ['type' => 'string'],

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'dsn' => 'example.com',
     'logrocket_key' => 'example/example',
     'environment' => null,
-    'log_level' => \Monolog\Logger::WARNING,
+    'log_level' => \Monolog\Level::Warning,
     'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,
@@ -73,7 +73,7 @@ Next to that there are some configuration options under Stores > Configuration >
 | `sample_rate`               | `1.0` | Configures the sample rate for error events, in the range of 0.0 to 1.0. |
 | `ignore_exceptions`         | `[]` | If the class being thrown matches any in this list, do not send it to Sentry, e.g., `[\Magento\Framework\Exception\NoSuchEntityException::class]` |
 | `error_types`               | `E_ALL` | If the Exception is an instance of [ErrorException](https://www.php.net/manual/en/class.errorexception.php), send the error to Sentry if it matches the error reporting. Uses the same syntax as [Error Reporting](https://www.php.net/manual/en/function.error-reporting.php), e.g., `E_ERROR` | E_WARNING`. |
-| `log_level`                 | `\Monolog\Logger::WARNING` | Specify from which logging level on Sentry should get the [messages](https://docs.sentry.io/platforms/php/usage/#capturing-messages). |
+| `log_level`                 | `\Monolog\Level::Warning` | Specify from which logging level on Sentry should get the [messages](https://docs.sentry.io/platforms/php/usage/#capturing-messages). |
 | `clean_stacktrace`          | `true` | Whether unnecessary files (like Interceptor.php, Proxy.php, and Factory.php) should be removed from the stacktrace. (They will not be removed if they threw the error.) |
 | `tracing_enabled`           | `false` | If set to true, tracing is enabled (bundle file is loaded automatically). |
 | `traces_sample_rate`        | `0.2` | If tracing is enabled, set the sample rate. A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. |
@@ -82,7 +82,7 @@ Next to that there are some configuration options under Stores > Configuration >
 | `performance_tracking_enabled` | `false` | if performance tracking is enabled, a performance report gets generated for the request. |
 | `performance_tracking_excluded_areas` | `['adminhtml', 'crontab']` | if `performance_tracking_enabled` is enabled, we recommend to exclude the `adminhtml` & `crontab` area. |
 | `enable_logs`               | `false` | This option enables the [logging integration](https://sentry.io/product/logs/), which allows the SDK to capture logs and send them to Sentry. |
-| `logger_log_level`          | `\Monolog\Logger::NOTICE` | If the logging integration is enabled, specify from which logging level the logger should log |
+| `logger_log_level`          | `\Monolog\Level::Notice` | If the logging integration is enabled, specify from which logging level the logger should log |
 | `js_sdk_version`            | `\JustBetter\Sentry\Block\SentryScript::CURRENT_VERSION` | If set, loads the explicit version of the JavaScript SDK of Sentry. |
 | `ignore_js_errors`          | `[]` | Array of JavaScript error messages which should not be sent to Sentry. (See also `ignoreErrors` in [Sentry documentation](https://docs.sentry.io/clients/javascript/config/)) |
 | `disable_default_integrations` | `[]` | Provide a list of FQCN of default integrations you do not want to use. [List of default integrations](https://github.com/getsentry/sentry-php/tree/master/src/Integration).|

--- a/view/adminhtml/templates/system/config/deployment-config-info.phtml
+++ b/view/adminhtml/templates/system/config/deployment-config-info.phtml
@@ -20,7 +20,7 @@
     'dsn' => 'example.com',
     'logrocket_key' => 'example/example',
     'environment' => null,
-    'log_level' => \Monolog\Logger::WARNING,
+    'log_level' => \Monolog\Level::Warning,
     'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,


### PR DESCRIPTION
Replaces deprecated methods in defaults/samples to prevent users from applying bad configs

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

During Composer runs, Magento (and some plugins) may bootstrap very early. Sample `env.php` in `README.md` reference `\Monolog\Logger::WARNING`. Just referencing that constant makes PHP autoload the `Monolog\Logger` class immediately. If, at that exact moment, the older PSR interface is what’s loaded (or cached), PHP detects an incompatibility between `Monolog\Logger` and `Psr\Log\LoggerInterface` and dies.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

This is mainly Doc changes (and aligning a default accordingly), and does not alter the running code in any way.
Prophilactic PR, LGTM™️ 🤓

**Checklist**

- [ ] I've ran `composer run codestyle`
- [ ] I've ran `composer run analyse`