### PR TITLE
use configured dsn-hostname for csp connect-src policy

### DIFF
--- a/Model/Collector/SentryRelatedCspCollector.php
+++ b/Model/Collector/SentryRelatedCspCollector.php
@@ -3,6 +3,7 @@
 namespace JustBetter\Sentry\Model\Collector;
 
 use JustBetter\Sentry\Helper\Data as DataHelper;
+use Laminas\Uri\UriFactory;
 use Magento\Csp\Api\PolicyCollectorInterface;
 use Magento\Csp\Model\Policy\FetchPolicy;
 
@@ -32,11 +33,16 @@ class SentryRelatedCspCollector implements PolicyCollectorInterface
                 false,
                 ['https://browser.sentry-cdn.com']
             );
-            $policies[] = new FetchPolicy(
-                'connect-src',
-                false,
-                ['https://*.ingest.sentry.io']
-            );
+
+            $dsn = $this->dataHelper->getDsn();
+            $dsnHost = is_string($dsn) ? UriFactory::factory($dsn)->getHost() : null;
+            if (!empty($dsnHost)) {
+                $policies[] = new FetchPolicy(
+                    'connect-src',
+                    false,
+                    [$dsnHost]
+                );
+            }
         }
 
         if ($this->dataHelper->isSpotlightEnabled()) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

in case the administrator has been configured a custom DSN, which does not point to the SASS Sentry, the CSPs will block the connection to this host. 

This PR replaces the fixed hostname from the policy and adds the configured hostname.

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`