### PR TITLE
csp: add report-uri if none is configured

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -94,6 +94,7 @@ class Data extends AbstractHelper
         'clean_stacktrace'                    => ['type' => 'bool'],
         'cron_monitoring_enabled'             => ['type' => 'bool'],
         'track_crons'                         => ['type' => 'array'],
+        'enable_csp_report_url'               => ['type' => 'bool'],
     ];
 
     /**
@@ -612,6 +613,16 @@ class Data extends AbstractHelper
     public function getIgnoreExceptions(): array
     {
         return $this->collectModuleConfig()['ignore_exceptions'] ?? [];
+    }
+
+    /**
+     * Whether the report-uri directive in the CSP is enabled.
+     *
+     * @return bool
+     */
+    public function isEnableCspReportUrl(): bool
+    {
+        return $this->collectModuleConfig()['enable_csp_report_url'] ?? false;
     }
 
     /**

--- a/Plugin/CspModeConfigManagerPlugin.php
+++ b/Plugin/CspModeConfigManagerPlugin.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Plugin;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Helper\Version;
+use Laminas\Uri\UriFactory;
+use Magento\Csp\Api\Data\ModeConfiguredInterface;
+use Magento\Csp\Api\ModeConfigManagerInterface;
+use Magento\Csp\Model\Mode\Data\ModeConfigured;
+
+class CspModeConfigManagerPlugin
+{
+    /**
+     * CspModeConfigManagerPlugin constructor.
+     *
+     * @param Version $version
+     * @param Data    $config
+     */
+    public function __construct(
+        private readonly Version $version,
+        private readonly Data $config
+    ) {
+    }
+
+    /**
+     * Gather the report-uri based on the Sentry DSN, if no uri has been set.
+     *
+     * @param ModeConfigManagerInterface $subject
+     * @param ModeConfiguredInterface    $result
+     *
+     * @return ModeConfiguredInterface
+     */
+    public function afterGetConfigured(ModeConfigManagerInterface $subject, ModeConfiguredInterface $result): ModeConfiguredInterface
+    {
+        if ($result->getReportUri() !== null || !$this->config->isActive() || !$this->config->isEnableCspReportUrl()) {
+            return $result;
+        }
+
+        $dsn = $this->config->getDSN();
+        if (!is_string($dsn) || empty($dsn)) {
+            return $result;
+        }
+
+        // DSN
+        // https://<key>@<organisation>.ingest.<region>.sentry.io/<project>
+        // https://<key>@example.com/<project>
+
+        // security-url
+        // https://<organisation>.ingest.<region>.sentry.io/api/<project>/security/?sentry_key=<key>
+        // https://example.com/api/<project>/security/?sentry_key=<key>
+
+        $uriParsed = UriFactory::factory($dsn);
+
+        $dsnPaths = explode('/', $uriParsed->getPath()); // the last one is the project-id
+        $reportUri = sprintf('https://%s/api/%s/security', $uriParsed->getHost(), $dsnPaths[count($dsnPaths) - 1]);
+
+        $params = [
+            'sentry_key'         => $uriParsed->getUserInfo(),
+            'sentry_release'     => $this->version->getValue(),
+            'sentry_environment' => $this->config->getEnvironment(),
+        ];
+
+        $params = array_filter($params);
+        if ($params !== []) {
+            $reportUri .= '&'.http_build_query($params);
+        }
+
+        return new ModeConfigured($result->isReportOnly(), $reportUri);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'performance_tracking_enabled' => true,
     'performance_tracking_excluded_areas' => [\Magento\Framework\App::AREA_ADMINHTML, \Magento\Framework\App::AREA_CRONTAB],
     'profiles_sample_rate' => 0.5,
-    'ignore_js_errors' => []
+    'ignore_js_errors' => [],
+    'enable_csp_report_url' => true,
 ]
 ```
 
@@ -90,7 +91,7 @@ Next to that there are some configuration options under Stores > Configuration >
 | `track_crons` | `[]` | Cron handles of crons to track with cron monitoring, [Sentry only supports 6 check-ins per minute](https://docs.sentry.io/platforms/php/crons/#rate-limits) Magento does many more. |
 | `spotlight` | `false` | Enable [Spotlight](https://spotlightjs.com/) on the page |
 | `spotlight_url` | - | Override the [Sidecar url](https://spotlightjs.com/sidecar/) |         
-                   
+| `enable_csp_report_url` | `false` | If set to true, the report-uri will be automatically added based on the DSN. |
 
 ### Configuration for Adobe Cloud
 Since Adobe Cloud doesn't allow you to add manually add content to the `env.php` file, the configuration can be done
@@ -143,7 +144,7 @@ public function execute(\Magento\Framework\Event\Observer $observer)
 Example: https://github.com/justbetter/magento2-sentry-filter-events
 
 This same thing is the case for
-|                                |                                                                                     | 
+|                                |                                                                                     |
 |--------------------------------|-------------------------------------------------------------------------------------|
 | sentry_before_send             | https://docs.sentry.io/platforms/php/configuration/options/#before_send             |
 | sentry_before_send_transaction | https://docs.sentry.io/platforms/php/configuration/options/#before_send_transaction |
@@ -164,7 +165,7 @@ Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
 Most importantly:
 - When making a PR please add a description what you've added, and if relevant why.
-- To save time on codestyle feedback, please run 
+- To save time on codestyle feedback, please run
     - `composer install`
     - `composer run codestyle`
     - `composer run analyse`

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -25,12 +25,17 @@
                 sortOrder="10" disabled="false"/>
     </type>
 
+    <!-- Content Security Policies -->
     <type name="Magento\Csp\Model\CompositePolicyCollector">
         <arguments>
             <argument name="collectors" xsi:type="array">
                 <item name="sentry" xsi:type="object" sortOrder="99">JustBetter\Sentry\Model\Collector\SentryRelatedCspCollector\Proxy</item>
             </argument>
         </arguments>
+    </type>
+
+    <type name="Magento\Csp\Api\ModeConfigManagerInterface">
+        <plugin name="sentry-set-report-uri" type="JustBetter\Sentry\Plugin\CspModeConfigManagerPlugin"/>
     </type>
 
     <type name="JustBetter\Sentry\Model\SentryLog">


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

this will add the CSP Report-URI based on the configured DSN. 

This change respect different Host-DSNs and regions

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`