### PR TITLE
ReadMe - Fix class references in performance tracking settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'traces_sample_rate' => 0.5,
     'disable_default_integrations' => [
         \Sentry\Integration\ModulesIntegration::class,
-    ]
+    ],
     'performance_tracking_enabled' => true,
-    'performance_tracking_excluded_areas' => [\Magento\Framework\App::AREA_ADMINHTML, \Magento\Framework\App::AREA_CRONTAB],
+    'performance_tracking_excluded_areas' => [\Magento\Framework\App\Area::AREA_ADMINHTML, \Magento\Framework\App\Area::AREA_CRONTAB],
     'profiles_sample_rate' => 0.5,
     'ignore_js_errors' => [],
     'enable_csp_report_url' => true,


### PR DESCRIPTION
**Summary**
This pull request makes a minor update to the example configuration in the `README.md` file to use the correct constant references for excluded performance tracking areas, log level, and a missing comma.

The missing comma causes a site error if the config is copied into the env.php file/

- Documentation update:
  * Updated the `performance_tracking_excluded_areas` array in the example configuration to use `\Magento\Framework\App\Area::AREA_ADMINHTML` and `\Magento\Framework\App\Area::AREA_CRONTAB` instead of the previous class constants, ensuring correct usage of Magento area constants.
  * Update `log_level` to correct class const as the previous class did not exist
  * Missing semicolon

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`