### PR TITLE
Fixed log level type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'dsn' => 'example.com',
     'logrocket_key' => 'example/example',
     'environment' => null,
-    'log_level' => \Monolog\Level::Warning,
+    'log_level' => \Monolog\Level::Warning->value,
     'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,

--- a/view/adminhtml/templates/system/config/deployment-config-info.phtml
+++ b/view/adminhtml/templates/system/config/deployment-config-info.phtml
@@ -20,7 +20,7 @@
     'dsn' => 'example.com',
     'logrocket_key' => 'example/example',
     'environment' => null,
-    'log_level' => \Monolog\Level::Warning,
+    'log_level' => \Monolog\Level::Warning->value,
     'error_types' => E_ALL,
     'ignore_exceptions' => [],
     'mage_mode_development' => false,


### PR DESCRIPTION
**Summary**

The previous default value for the “log_level” configuration triggers the following error within Magento:

There is an error in /project/vendor/magento/framework/App/DeploymentConfig.php at line: 275
preg_match(): Argument #2 ($subject) must be of type string, Monolog\Level given#0 /project/vendor/magento/framework/App/DeploymentConfig.php(275): preg_match('~^#env\\(\\s*(?<n...', Object(Monolog\Level), Array)

**Cause**

The default configuration value was previously changed:
before: \Monolog\Logger::WARNING
now: \Monolog\Level::Warning

Problem: \Monolog\Logger was a PHP class. \Monolog\Level is an ENUM.

To ensure that Magento 2 can process the configuration correctly, the following special syntax is required:

\Monolog\Level::Warning->value

**Result**

before: bin/magento app:config:import = ERROR
after: bin/magento app:config:import = FINE