### PR TITLE
Resilience layer

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -100,6 +100,15 @@ class Data extends AbstractHelper
         'cron_monitoring_enabled'             => ['type' => 'bool'],
         'track_crons'                         => ['type' => 'array'],
         'enable_csp_report_url'               => ['type' => 'bool'],
+        // Resilient delivery (async MQ + circuit breaker)
+        'async_sending_enabled'               => ['type' => 'bool', 'default' => false],
+        'async_fallback_on_circuit_open'      => ['type' => 'bool', 'default' => true],
+        'circuit_breaker_enabled'             => ['type' => 'bool', 'default' => true],
+        'circuit_breaker_failure_threshold'   => ['type' => 'int', 'default' => 5],
+        'circuit_breaker_recovery_timeout'    => ['type' => 'int', 'default' => 60],
+        'circuit_breaker_success_threshold'   => ['type' => 'int', 'default' => 2],
+        'http_timeout'                        => ['type' => 'int', 'default' => 2],
+        'http_connect_timeout'                => ['type' => 'int', 'default' => 1],
     ];
 
     /**
@@ -654,6 +663,70 @@ class Data extends AbstractHelper
     public function isEnableCspReportUrl(): bool
     {
         return $this->collectModuleConfig()['enable_csp_report_url'] ?? false;
+    }
+
+    /**
+     * Whether Sentry envelopes should be published to Magento MQ instead of HTTP on the request path.
+     */
+    public function isAsyncSendingEnabled(): bool
+    {
+        return (bool) ($this->collectModuleConfig()['async_sending_enabled'] ?? false);
+    }
+
+    /**
+     * When the circuit is open (or sync send fails), fall back to async MQ delivery.
+     */
+    public function isAsyncFallbackOnCircuitOpen(): bool
+    {
+        return (bool) ($this->collectModuleConfig()['async_fallback_on_circuit_open'] ?? true);
+    }
+
+    /**
+     * Whether the circuit breaker is enabled for synchronous Sentry HTTP calls.
+     */
+    public function isCircuitBreakerEnabled(): bool
+    {
+        return (bool) ($this->collectModuleConfig()['circuit_breaker_enabled'] ?? true);
+    }
+
+    /**
+     * Consecutive HTTP failures before the circuit opens.
+     */
+    public function getCircuitBreakerFailureThreshold(): int
+    {
+        return max(1, (int) ($this->collectModuleConfig()['circuit_breaker_failure_threshold'] ?? 5));
+    }
+
+    /**
+     * Seconds to wait before probing Sentry again after the circuit opens.
+     */
+    public function getCircuitBreakerRecoveryTimeout(): int
+    {
+        return max(1, (int) ($this->collectModuleConfig()['circuit_breaker_recovery_timeout'] ?? 60));
+    }
+
+    /**
+     * Successful probes required in half-open state before closing the circuit.
+     */
+    public function getCircuitBreakerSuccessThreshold(): int
+    {
+        return max(1, (int) ($this->collectModuleConfig()['circuit_breaker_success_threshold'] ?? 2));
+    }
+
+    /**
+     * HTTP timeout (seconds) for Sentry envelope delivery.
+     */
+    public function getHttpTimeout(): int
+    {
+        return max(1, (int) ($this->collectModuleConfig()['http_timeout'] ?? 2));
+    }
+
+    /**
+     * HTTP connect timeout (seconds) for Sentry envelope delivery.
+     */
+    public function getHttpConnectTimeout(): int
+    {
+        return max(1, (int) ($this->collectModuleConfig()['http_connect_timeout'] ?? 1));
     }
 
     /**

--- a/Model/CircuitBreaker.php
+++ b/Model/CircuitBreaker.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model;
+
+use JustBetter\Sentry\Helper\Data;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+
+/**
+ * Cache-backed circuit breaker for outbound Sentry HTTP calls.
+ *
+ * States: closed (normal) → open (fail fast) → half-open (probe) → closed.
+ */
+class CircuitBreaker
+{
+    public const STATE_CLOSED = 'closed';
+    public const STATE_OPEN = 'open';
+    public const STATE_HALF_OPEN = 'half_open';
+
+    private const CACHE_KEY = 'justbetter_sentry_circuit_breaker';
+    private const CACHE_TAG = 'JUSTBETTER_SENTRY_CIRCUIT_BREAKER';
+
+    /**
+     * @var array{state:string,failures:int,successes:int,opened_at:float}|null
+     */
+    private ?array $state = null;
+
+    /**
+     * @param CacheInterface $cache
+     * @param Json           $serializer
+     * @param Data           $helper
+     */
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly Json $serializer,
+        private readonly Data $helper
+    ) {
+    }
+
+    /**
+     * Whether a sync HTTP attempt is allowed.
+     */
+    public function allowRequest(): bool
+    {
+        if (!$this->helper->isCircuitBreakerEnabled()) {
+            return true;
+        }
+
+        $state = $this->getState();
+
+        return match ($state['state']) {
+            self::STATE_CLOSED, self::STATE_HALF_OPEN => true,
+            self::STATE_OPEN => $this->tryTransitionToHalfOpen($state),
+            default          => true,
+        };
+    }
+
+    /**
+     * Record a successful Sentry HTTP delivery.
+     */
+    public function recordSuccess(): void
+    {
+        if (!$this->helper->isCircuitBreakerEnabled()) {
+            return;
+        }
+
+        $state = $this->getState();
+
+        if ($state['state'] === self::STATE_HALF_OPEN) {
+            $state['successes']++;
+            if ($state['successes'] >= $this->helper->getCircuitBreakerSuccessThreshold()) {
+                $this->resetToClosed();
+
+                return;
+            }
+            $this->persist($state);
+
+            return;
+        }
+
+        if ($state['failures'] !== 0 || $state['state'] !== self::STATE_CLOSED) {
+            $this->resetToClosed();
+        }
+    }
+
+    /**
+     * Record a failed Sentry HTTP delivery.
+     */
+    public function recordFailure(): void
+    {
+        if (!$this->helper->isCircuitBreakerEnabled()) {
+            return;
+        }
+
+        $state = $this->getState();
+
+        if ($state['state'] === self::STATE_HALF_OPEN) {
+            $this->openCircuit($this->helper->getCircuitBreakerFailureThreshold());
+
+            return;
+        }
+
+        $state['failures']++;
+        $state['successes'] = 0;
+
+        if ($state['failures'] >= $this->helper->getCircuitBreakerFailureThreshold()) {
+            $this->openCircuit($state['failures']);
+
+            return;
+        }
+
+        $this->persist($state);
+    }
+
+    /**
+     * Load circuit breaker state from in-memory cache or Magento cache.
+     *
+     * @return array{state:string,failures:int,successes:int,opened_at:float}
+     */
+    private function getState(): array
+    {
+        if ($this->state !== null) {
+            return $this->state;
+        }
+
+        $cached = $this->cache->load(self::CACHE_KEY);
+        if (!is_string($cached) || $cached === '') {
+            return $this->state = $this->closedState();
+        }
+
+        try {
+            $decoded = $this->serializer->unserialize($cached);
+        } catch (\InvalidArgumentException) {
+            return $this->state = $this->closedState();
+        }
+
+        if (!is_array($decoded)) {
+            return $this->state = $this->closedState();
+        }
+
+        return $this->state = [
+            'state'     => (string) ($decoded['state'] ?? self::STATE_CLOSED),
+            'failures'  => (int) ($decoded['failures'] ?? 0),
+            'successes' => (int) ($decoded['successes'] ?? 0),
+            'opened_at' => (float) ($decoded['opened_at'] ?? 0.0),
+        ];
+    }
+
+    /**
+     * Transition from open to half-open after the recovery timeout.
+     *
+     * @param array{state:string,failures:int,successes:int,opened_at:float} $state
+     */
+    private function tryTransitionToHalfOpen(array $state): bool
+    {
+        $recoveryTimeout = $this->helper->getCircuitBreakerRecoveryTimeout();
+        if ($state['opened_at'] <= 0
+            || (microtime(true) - $state['opened_at']) < $recoveryTimeout
+        ) {
+            return false;
+        }
+
+        $this->persist([
+            'state'     => self::STATE_HALF_OPEN,
+            'failures'  => $state['failures'],
+            'successes' => 0,
+            'opened_at' => $state['opened_at'],
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Default closed circuit state.
+     *
+     * @return array{state:string,failures:int,successes:int,opened_at:float}
+     */
+    private function closedState(): array
+    {
+        return [
+            'state'     => self::STATE_CLOSED,
+            'failures'  => 0,
+            'successes' => 0,
+            'opened_at' => 0.0,
+        ];
+    }
+
+    /**
+     * Reset circuit to closed and clear counters.
+     */
+    private function resetToClosed(): void
+    {
+        $this->persist($this->closedState());
+    }
+
+    /**
+     * Open the circuit after failure threshold is reached.
+     *
+     * @param int $failures Current failure count
+     */
+    private function openCircuit(int $failures): void
+    {
+        $this->persist([
+            'state'     => self::STATE_OPEN,
+            'failures'  => $failures,
+            'successes' => 0,
+            'opened_at' => microtime(true),
+        ]);
+    }
+
+    /**
+     * Persist circuit state to memory and Magento cache.
+     *
+     * @param array{state:string,failures:int,successes:int,opened_at:float} $state
+     */
+    private function persist(array $state): void
+    {
+        $this->state = $state;
+        // Keep state longer than recovery window so open state survives across requests.
+        $ttl = max(300, $this->helper->getCircuitBreakerRecoveryTimeout() * 5);
+        $this->cache->save(
+            (string) $this->serializer->serialize($state),
+            self::CACHE_KEY,
+            [self::CACHE_TAG],
+            $ttl
+        );
+    }
+}

--- a/Model/Queue/Consumer/SentryEventConsumer.php
+++ b/Model/Queue/Consumer/SentryEventConsumer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model\Queue\Consumer;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use JustBetter\Sentry\Model\Transport\EnvelopeSender;
+use Throwable;
+
+/**
+ * Delivers queued Sentry envelopes as-is (fire-time timestamps already in payload).
+ * Does not short-circuit on the circuit breaker — only records success/failure for the CB.
+ */
+class SentryEventConsumer
+{
+    /**
+     * @param EnvelopeSender $envelopeSender
+     * @param CircuitBreaker $circuitBreaker
+     * @param Data           $helper
+     */
+    public function __construct(
+        private readonly EnvelopeSender $envelopeSender,
+        private readonly CircuitBreaker $circuitBreaker,
+        private readonly Data $helper
+    ) {
+    }
+
+    /**
+     * Deliver a queued Sentry envelope and update the circuit breaker.
+     *
+     * @param string $payload Serialized Sentry envelope
+     *
+     * @throws Throwable Re-thrown so the queue framework can retry
+     */
+    public function process(string $payload): void
+    {
+        if (!$this->helper->isActive() || $payload === '') {
+            return;
+        }
+
+        try {
+            $this->envelopeSender->send($payload);
+            $this->circuitBreaker->recordSuccess();
+        } catch (Throwable $exception) {
+            $this->circuitBreaker->recordFailure();
+
+            throw $exception;
+        }
+    }
+}

--- a/Model/Queue/Publisher/SentryEventPublisher.php
+++ b/Model/Queue/Publisher/SentryEventPublisher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model\Queue\Publisher;
+
+use Magento\Framework\MessageQueue\PublisherInterface;
+
+/**
+ * Publishes a pre-serialized Sentry envelope string to Magento MQ.
+ */
+class SentryEventPublisher
+{
+    public const TOPIC_NAME = 'justbetter.sentry.event.send';
+
+    /**
+     * @param PublisherInterface $publisher
+     */
+    public function __construct(
+        private readonly PublisherInterface $publisher
+    ) {
+    }
+
+    /**
+     * Publish a serialized Sentry envelope to Magento MQ.
+     *
+     * @param string $payload Serialized Sentry envelope (event timestamp + sent_at frozen at fire time)
+     */
+    public function publish(string $payload): void
+    {
+        $this->publisher->publish(self::TOPIC_NAME, $payload);
+    }
+}

--- a/Model/SentryInteraction.php
+++ b/Model/SentryInteraction.php
@@ -7,6 +7,7 @@ namespace JustBetter\Sentry\Model;
 // phpcs:disable Magento2.Functions.DiscouragedFunction
 
 use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\Transport\ResilientTransportFactory;
 use Magento\Authorization\Model\UserContextInterface;
 use Magento\Backend\Model\Auth\Session as AdminSession;
 use Magento\Customer\Model\Session as CustomerSession;
@@ -36,16 +37,18 @@ class SentryInteraction
     /**
      * SentryInteraction constructor.
      *
-     * @param State           $appState
-     * @param ConfigInterface $omConfigInterface
-     * @param Data            $sentryHelper
-     * @param RemoteAddress   $remoteAddress
+     * @param State                     $appState
+     * @param ConfigInterface           $omConfigInterface
+     * @param Data                      $sentryHelper
+     * @param RemoteAddress             $remoteAddress
+     * @param ResilientTransportFactory $resilientTransportFactory
      */
     public function __construct(
         private State $appState,
         private ConfigInterface $omConfigInterface,
         private Data $sentryHelper,
-        private RemoteAddress $remoteAddress
+        private RemoteAddress $remoteAddress,
+        private ResilientTransportFactory $resilientTransportFactory
     ) {
     }
 
@@ -58,10 +61,14 @@ class SentryInteraction
      */
     public function initialize(array $config): void // @phpstan-ignore missingType.iterableValue
     {
-        $client = ClientBuilder::create($config)
+        $builder = ClientBuilder::create($config)
             ->setSdkIdentifier(static::SDK_IDENTIFIER);
 
-        SentrySdk::init()->bindClient($client->getClient());
+        $builder->setTransport(
+            $this->resilientTransportFactory->create($builder->getOptions())
+        );
+
+        SentrySdk::init()->bindClient($builder->getClient());
     }
 
     /**

--- a/Model/SentryLog.php
+++ b/Model/SentryLog.php
@@ -49,7 +49,7 @@ class SentryLog
         $config = $this->data->collectModuleConfig();
         $customTags = [];
 
-        if ($config['enable_logs'] && $logLevel >= $config['logger_log_level']) {
+        if (($config['enable_logs'] ?? false) && $logLevel >= ($config['logger_log_level'] ?? 300)) {
             match ($logLevel) {
                 Monolog::DEBUG   => \Sentry\Logger()->debug($message, $context),
                 Monolog::INFO    => \Sentry\Logger()->info($message, $context),
@@ -60,7 +60,7 @@ class SentryLog
             };
         }
 
-        if ($logLevel < (int) $config['log_level']) {
+        if ($logLevel < (int) ($config['log_level'] ?? 0)) {
             return;
         }
 

--- a/Model/Transport/EnvelopeSender.php
+++ b/Model/Transport/EnvelopeSender.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model\Transport;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\SentryInteraction;
+use RuntimeException;
+use Sentry\Client;
+use Sentry\HttpClient\HttpClient;
+use Sentry\HttpClient\Request;
+use Sentry\Options;
+use Sentry\Transport\ResultStatus;
+
+/**
+ * Sends a pre-serialized Sentry envelope over HTTP (used by the async consumer).
+ */
+class EnvelopeSender
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        private readonly Data $helper
+    ) {
+    }
+
+    /**
+     * POST a pre-serialized envelope to the configured Sentry DSN.
+     *
+     * Payload must already include fire-time fields (event "timestamp",
+     * envelope "sent_at") — this method does not re-serialize or re-stamp.
+     *
+     * @param string $payload Envelope body produced at publish/fire time
+     *
+     * @throws RuntimeException When delivery fails
+     */
+    public function send(string $payload): void
+    {
+        if ($payload === '') {
+            throw new RuntimeException('Sentry envelope payload is empty.');
+        }
+
+        $dsn = $this->helper->getDSN();
+        if (!is_string($dsn) || $dsn === '') {
+            throw new RuntimeException('Sentry DSN is not configured.');
+        }
+
+        $options = new Options([
+            'dsn'                  => $dsn,
+            'http_timeout'         => $this->helper->getHttpTimeout(),
+            'http_connect_timeout' => $this->helper->getHttpConnectTimeout(),
+        ]);
+
+        $request = new Request();
+        $request->setStringBody($payload);
+
+        $httpClient = new HttpClient(SentryInteraction::SDK_IDENTIFIER, Client::SDK_VERSION);
+        $response = $httpClient->sendRequest($request, $options);
+
+        if ($response->hasError()) {
+            throw new RuntimeException(
+                sprintf('Sentry envelope delivery failed: %s', $response->getError())
+            );
+        }
+
+        $status = ResultStatus::createFromHttpStatusCode($response->getStatusCode());
+        if ((string) $status !== (string) ResultStatus::success()) {
+            throw new RuntimeException(
+                sprintf(
+                    'Sentry envelope delivery failed with HTTP %d (%s).',
+                    $response->getStatusCode(),
+                    (string) $status
+                )
+            );
+        }
+    }
+}

--- a/Model/Transport/ResilientTransport.php
+++ b/Model/Transport/ResilientTransport.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model\Transport;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
+use Sentry\Event;
+use Sentry\Serializer\PayloadSerializerInterface;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Sentry\Transport\TransportInterface;
+use Throwable;
+
+/**
+ * Request-path transport: queue when configured / circuit open, otherwise short HTTP.
+ */
+class ResilientTransport implements TransportInterface
+{
+    /**
+     * @var bool
+     */
+    private bool $sending = false;
+
+    /**
+     * @param TransportInterface         $httpTransport
+     * @param PayloadSerializerInterface $payloadSerializer
+     * @param SentryEventPublisher       $publisher
+     * @param CircuitBreaker             $circuitBreaker
+     * @param Data                       $helper
+     */
+    public function __construct(
+        private readonly TransportInterface $httpTransport,
+        private readonly PayloadSerializerInterface $payloadSerializer,
+        private readonly SentryEventPublisher $publisher,
+        private readonly CircuitBreaker $circuitBreaker,
+        private readonly Data $helper
+    ) {
+    }
+
+    /**
+     * Send event via queue or HTTP depending on configuration and circuit state.
+     *
+     * @param Event $event
+     */
+    public function send(Event $event): Result
+    {
+        // Avoid re-entry if publishing/logging triggers another capture.
+        if ($this->sending) {
+            return new Result(ResultStatus::skipped(), $event);
+        }
+
+        $this->sending = true;
+
+        try {
+            return $this->shouldQueue()
+                ? $this->queue($event)
+                : $this->sendHttp($event);
+        } catch (Throwable) {
+            return new Result(ResultStatus::failed(), $event);
+        } finally {
+            $this->sending = false;
+        }
+    }
+
+    /**
+     * Close the underlying HTTP transport.
+     *
+     * @param int|null $timeout
+     */
+    public function close(?int $timeout = null): Result
+    {
+        return $this->httpTransport->close($timeout);
+    }
+
+    /**
+     * Queue always when async is on; otherwise only as fallback when the circuit is open.
+     */
+    private function shouldQueue(): bool
+    {
+        if ($this->helper->isAsyncSendingEnabled()) {
+            return true;
+        }
+
+        return $this->helper->isCircuitBreakerEnabled()
+            && $this->helper->isAsyncFallbackOnCircuitOpen()
+            && !$this->circuitBreaker->allowRequest();
+    }
+
+    /**
+     * Attempt synchronous HTTP delivery and update the circuit breaker.
+     *
+     * @param Event $event
+     */
+    private function sendHttp(Event $event): Result
+    {
+        try {
+            $result = $this->httpTransport->send($event);
+        } catch (Throwable) {
+            $this->circuitBreaker->recordFailure();
+
+            return $this->fallbackToQueueOrFail($event);
+        }
+
+        if ($this->isSuccess($result)) {
+            $this->circuitBreaker->recordSuccess();
+
+            return $result;
+        }
+
+        if ($this->isServerSideFailure($result)) {
+            $this->circuitBreaker->recordFailure();
+
+            return $this->fallbackToQueueOrFail($event, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Queue the event when fallback is enabled, otherwise return the failed result.
+     *
+     * @param Event       $event
+     * @param Result|null $result
+     */
+    private function fallbackToQueueOrFail(Event $event, ?Result $result = null): Result
+    {
+        if ($this->helper->isAsyncFallbackOnCircuitOpen()) {
+            return $this->queue($event);
+        }
+
+        return $result ?? new Result(ResultStatus::failed(), $event);
+    }
+
+    /**
+     * Serialize at fire time and enqueue the envelope bytes.
+     *
+     * Consumer POSTs this as-is, so Sentry keeps payload "timestamp" / "sent_at".
+     *
+     * @param Event $event
+     */
+    private function queue(Event $event): Result
+    {
+        if ($event->getTimestamp() === null) {
+            $event->setTimestamp(microtime(true));
+        }
+
+        $this->publisher->publish($this->payloadSerializer->serialize($event));
+
+        return new Result(ResultStatus::success(), $event);
+    }
+
+    /**
+     * Whether the transport result indicates success.
+     *
+     * @param Result $result
+     */
+    private function isSuccess(Result $result): bool
+    {
+        return (string) $result->getStatus() === (string) ResultStatus::success();
+    }
+
+    /**
+     * Whether the transport result should count as a circuit-breaker failure.
+     *
+     * @param Result $result
+     */
+    private function isServerSideFailure(Result $result): bool
+    {
+        return in_array((string) $result->getStatus(), [
+            (string) ResultStatus::failed(),
+            (string) ResultStatus::unknown(),
+            (string) ResultStatus::rateLimit(),
+        ], true);
+    }
+}

--- a/Model/Transport/ResilientTransportFactory.php
+++ b/Model/Transport/ResilientTransportFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Model\Transport;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
+use JustBetter\Sentry\Model\SentryInteraction;
+use Psr\Log\NullLogger;
+use Sentry\Client;
+use Sentry\HttpClient\HttpClient;
+use Sentry\Options;
+use Sentry\Serializer\PayloadSerializer;
+use Sentry\Transport\HttpTransport;
+use Sentry\Transport\TransportInterface;
+
+/**
+ * Builds a resilient transport bound to the active Sentry Options instance.
+ */
+class ResilientTransportFactory
+{
+    /**
+     * @param SentryEventPublisher $publisher
+     * @param CircuitBreaker       $circuitBreaker
+     * @param Data                 $helper
+     */
+    public function __construct(
+        private readonly SentryEventPublisher $publisher,
+        private readonly CircuitBreaker $circuitBreaker,
+        private readonly Data $helper
+    ) {
+    }
+
+    /**
+     * Create transport for the given Sentry client options.
+     *
+     * @param Options $options
+     */
+    public function create(Options $options): TransportInterface
+    {
+        $httpClient = new HttpClient(SentryInteraction::SDK_IDENTIFIER, Client::SDK_VERSION);
+        $payloadSerializer = new PayloadSerializer($options);
+        $httpTransport = new HttpTransport(
+            $options,
+            $httpClient,
+            $payloadSerializer,
+            new NullLogger()
+        );
+
+        return new ResilientTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $this->publisher,
+            $this->circuitBreaker,
+            $this->helper
+        );
+    }
+}

--- a/Plugin/GlobalExceptionCatcher.php
+++ b/Plugin/GlobalExceptionCatcher.php
@@ -103,12 +103,16 @@ class GlobalExceptionCatcher
             return $proceed(...$args);
         }
 
-        $config = $this->prepareConfig();
-
-        $this->sentryInteraction->initialize(array_filter($config->getData()));
-        if (($subject instanceof \Symfony\Component\Console\Command\Command)
-            || ($subject instanceof \Magento\Framework\AppInterface)) {
-            $this->sentryPerformance->startTransaction($subject, ...$args);
+        try {
+            $config = $this->prepareConfig();
+            $this->sentryInteraction->initialize(array_filter($config->getData()));
+            if (($subject instanceof \Symfony\Component\Console\Command\Command)
+                || ($subject instanceof \Magento\Framework\AppInterface)) {
+                $this->sentryPerformance->startTransaction($subject, ...$args);
+            }
+        } catch (Throwable) {
+            // Sentry bootstrap must never take down Magento.
+            return $proceed(...$args);
         }
 
         try {
@@ -135,6 +139,9 @@ class GlobalExceptionCatcher
 
         $config->setSpotlight($this->sentryHelper->isSpotlightEnabled());
         $config->setDsn($this->sentryHelper->getDSN());
+        // Keep outbound HTTP short so a degraded Sentry cannot stall Magento.
+        $config->setHttpTimeout($this->sentryHelper->getHttpTimeout());
+        $config->setHttpConnectTimeout($this->sentryHelper->getHttpConnectTimeout());
         if ($release = $this->releaseIdentifier->getReleaseId()) {
             $config->setRelease($release);
         }

--- a/Plugin/Profiling/ExchangePlugin.php
+++ b/Plugin/Profiling/ExchangePlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustBetter\Sentry\Plugin\Profiling;
 
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
 use Magento\Framework\MessageQueue\Bulk\ExchangeInterface as BulkExchangeInterface;
 use Magento\Framework\MessageQueue\EnvelopeInterface;
 use Magento\Framework\MessageQueue\ExchangeInterface;
@@ -21,6 +22,11 @@ class ExchangePlugin
      */
     public function beforeEnqueue(ExchangeInterface|BulkExchangeInterface $subject, ?string $topic, $envelopes): array // @phpstan-ignore missingType.iterableValue
     {
+        // Never wrap our own async Sentry delivery — that would nest envelopes and risk recursion.
+        if ($topic === SentryEventPublisher::TOPIC_NAME) {
+            return [$topic, $envelopes];
+        }
+
         $parentSpan = \Sentry\SentrySdk::getCurrentHub()->getSpan();
         if (!$parentSpan instanceof \Sentry\Tracing\Span) {
             return [$topic, $envelopes];

--- a/Plugin/Profiling/QueueMessageEncoderPlugin.php
+++ b/Plugin/Profiling/QueueMessageEncoderPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustBetter\Sentry\Plugin\Profiling;
 
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
 use Magento\Framework\MessageQueue\MessageEncoder;
 
 class QueueMessageEncoderPlugin
@@ -20,6 +21,11 @@ class QueueMessageEncoderPlugin
      */
     public function beforeDecode(MessageEncoder $subject, string $topic, $message, $requestType = true): array
     {
+        // Our own delivery topic carries a raw Sentry envelope, not Magento business payload.
+        if ($topic === SentryEventPublisher::TOPIC_NAME) {
+            return [$topic, $message, $requestType];
+        }
+
         $body = json_decode($message, true);
 
         if (!isset($body['sentry_trace']) && !isset($body['sentry_baggage'])) {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ This module uses the [Magento Deployment Configuration](https://devdocs.magento.
     'profiles_sample_rate' => 0.5,
     'ignore_js_errors' => [],
     'enable_csp_report_url' => true,
+    // Resilient delivery (protects the storefront critical path)
+    'async_sending_enabled' => true,
+    'async_fallback_on_circuit_open' => true,
+    'circuit_breaker_enabled' => true,
+    'circuit_breaker_failure_threshold' => 5,
+    'circuit_breaker_recovery_timeout' => 60,
+    'circuit_breaker_success_threshold' => 2,
+    'http_timeout' => 2,
+    'http_connect_timeout' => 1,
 ]
 ```
 
@@ -97,6 +106,28 @@ Next to that there are some configuration options under Stores > Configuration >
 | `spotlight` | `false` | Enable [Spotlight](https://spotlightjs.com/) on the page |
 | `spotlight_url` | - | Override the [Sidecar url](https://spotlightjs.com/sidecar/) |         
 | `enable_csp_report_url` | `false` | If set to true, the report-uri will be automatically added based on the DSN. |
+| `async_sending_enabled` | `false` | When `true`, Sentry envelopes are published to Magento MQ on the request path and delivered by the `justbetter.sentry.event` consumer. Envelope `sent_at` / event timestamps are frozen at **publish** time (not consumer send time). |
+| `async_fallback_on_circuit_open` | `true` | If synchronous HTTP fails or the circuit breaker is open, fall back to async MQ publishing instead of blocking / dropping immediately. |
+| `circuit_breaker_enabled` | `true` | Fail fast on synchronous Sentry HTTP after repeated failures so a degraded Sentry cannot stall shoppers. |
+| `circuit_breaker_failure_threshold` | `5` | Consecutive HTTP failures before the circuit opens. |
+| `circuit_breaker_recovery_timeout` | `60` | Seconds to wait before allowing a probe request after the circuit opens. |
+| `circuit_breaker_success_threshold` | `2` | Successful probes in half-open state required before closing the circuit. |
+| `http_timeout` | `2` | Total HTTP timeout (seconds) for Sentry envelope delivery (sync + consumer). Keep low on storefront. |
+| `http_connect_timeout` | `1` | HTTP connect timeout (seconds) for Sentry envelope delivery. |
+
+### Resilient delivery (async + circuit breaker)
+
+Sentry HTTP is no longer allowed to sit unbounded on the Magento request path:
+
+1. **Async mode** (`async_sending_enabled`): the resilient transport serializes the Sentry envelope **immediately** (so timestamps reflect publish/capture time) and publishes it to Magento MQ topic `justbetter.sentry.event.send`. The `justbetter.sentry.event` consumer delivers the same payload later via HTTP.
+2. **Sync mode + circuit breaker**: HTTP is attempted with short timeouts. After `circuit_breaker_failure_threshold` failures the circuit opens and sync calls fail fast. With `async_fallback_on_circuit_open`, events are queued instead of lost.
+3. Transport / capture failures are swallowed so Magento never 500s because Sentry is down.
+
+Run the consumer (or rely on `cron_consumers_runner`):
+
+```bash
+bin/magento queue:consumers:start justbetter.sentry.event
+```
 
 ### Configuration for Adobe Cloud
 Since Adobe Cloud doesn't allow you to add manually add content to the `env.php` file, the configuration can be done

--- a/Test/Unit/Model/CircuitBreakerTest.php
+++ b/Test/Unit/Model/CircuitBreakerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Test\Unit\Model;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+class CircuitBreakerTest extends TestCase
+{
+    /**
+     * @var CacheInterface&Stub
+     */
+    private $cache;
+
+    /**
+     * @var Data&Stub
+     */
+    private $helper;
+
+    /**
+     * @var Json
+     */
+    private Json $serializer;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $storage = [];
+
+    protected function setUp(): void
+    {
+        $this->storage = [];
+        $this->serializer = new Json();
+        $this->helper = $this->createStub(Data::class);
+        $this->cache = $this->createStub(CacheInterface::class);
+
+        $this->cache->method('load')->willReturnCallback(
+            function (string $key): string|false {
+                if (!array_key_exists($key, $this->storage)) {
+                    return false;
+                }
+
+                return $this->storage[$key];
+            }
+        );
+        $this->cache->method('save')->willReturnCallback(
+            function (string $data, string $key): bool {
+                $this->storage[$key] = $data;
+
+                return true;
+            }
+        );
+
+        $this->helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $this->helper->method('getCircuitBreakerFailureThreshold')->willReturn(3);
+        $this->helper->method('getCircuitBreakerSuccessThreshold')->willReturn(2);
+        $this->helper->method('getCircuitBreakerRecoveryTimeout')->willReturn(60);
+    }
+
+    private function createBreaker(
+        ?CacheInterface $cache = null,
+        ?Data $helper = null
+    ): CircuitBreaker {
+        return new CircuitBreaker(
+            $cache ?? $this->cache,
+            $this->serializer,
+            $helper ?? $this->helper
+        );
+    }
+
+    public function testAllowRequestWhenDisabled(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(false);
+
+        $this->assertTrue($this->createBreaker(helper: $helper)->allowRequest());
+    }
+
+    public function testStartsClosedAndAllowsRequests(): void
+    {
+        $this->assertTrue($this->createBreaker()->allowRequest());
+    }
+
+    public function testOpensAfterFailureThreshold(): void
+    {
+        $breaker = $this->createBreaker();
+
+        $breaker->recordFailure();
+        $breaker->recordFailure();
+        $this->assertTrue($breaker->allowRequest());
+
+        $breaker->recordFailure();
+        $this->assertFalse($breaker->allowRequest());
+    }
+
+    public function testRecordSuccessResetsFailuresWhileClosed(): void
+    {
+        $breaker = $this->createBreaker();
+
+        $breaker->recordFailure();
+        $breaker->recordFailure();
+        $breaker->recordSuccess();
+
+        $breaker->recordFailure();
+        $breaker->recordFailure();
+        $this->assertTrue($breaker->allowRequest());
+    }
+
+    public function testHalfOpenAfterRecoveryTimeoutThenClosesOnSuccessThreshold(): void
+    {
+        $this->storage['justbetter_sentry_circuit_breaker'] = (string) $this->serializer->serialize([
+            'state'     => CircuitBreaker::STATE_OPEN,
+            'failures'  => 3,
+            'successes' => 0,
+            'opened_at' => microtime(true) - 120,
+        ]);
+
+        $breaker = $this->createBreaker();
+
+        $this->assertTrue($breaker->allowRequest());
+
+        $breaker->recordSuccess();
+        $breaker->recordSuccess();
+
+        $state = $this->serializer->unserialize($this->storage['justbetter_sentry_circuit_breaker']);
+        $this->assertIsArray($state);
+        $this->assertSame(CircuitBreaker::STATE_CLOSED, $state['state']);
+        $this->assertSame(0, $state['failures']);
+    }
+
+    public function testHalfOpenFailureReopensCircuit(): void
+    {
+        $this->storage['justbetter_sentry_circuit_breaker'] = (string) $this->serializer->serialize([
+            'state'     => CircuitBreaker::STATE_HALF_OPEN,
+            'failures'  => 3,
+            'successes' => 0,
+            'opened_at' => microtime(true) - 120,
+        ]);
+
+        $breaker = $this->createBreaker();
+        $breaker->recordFailure();
+
+        $state = $this->serializer->unserialize($this->storage['justbetter_sentry_circuit_breaker']);
+        $this->assertIsArray($state);
+        $this->assertSame(CircuitBreaker::STATE_OPEN, $state['state']);
+        $this->assertFalse($breaker->allowRequest());
+    }
+
+    public function testRecordSuccessAndFailureNoopWhenDisabled(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(false);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->never())->method('save');
+
+        $breaker = $this->createBreaker($cache, $helper);
+        $breaker->recordSuccess();
+        $breaker->recordFailure();
+    }
+
+    public function testCorruptCacheFallsBackToClosed(): void
+    {
+        $this->storage['justbetter_sentry_circuit_breaker'] = 'not-json';
+
+        $this->assertTrue($this->createBreaker()->allowRequest());
+    }
+}

--- a/Test/Unit/Model/Queue/Consumer/SentryEventConsumerTest.php
+++ b/Test/Unit/Model/Queue/Consumer/SentryEventConsumerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Test\Unit\Model\Queue\Consumer;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use JustBetter\Sentry\Model\Queue\Consumer\SentryEventConsumer;
+use JustBetter\Sentry\Model\Transport\EnvelopeSender;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SentryEventConsumerTest extends TestCase
+{
+    public function testSkipsWhenModuleInactive(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isActive')->willReturn(false);
+
+        $envelopeSender = $this->createMock(EnvelopeSender::class);
+        $envelopeSender->expects($this->never())->method('send');
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->expects($this->never())->method('recordSuccess');
+        $circuitBreaker->expects($this->never())->method('recordFailure');
+
+        $consumer = new SentryEventConsumer($envelopeSender, $circuitBreaker, $helper);
+        $consumer->process('payload');
+    }
+
+    public function testSkipsEmptyPayload(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isActive')->willReturn(true);
+
+        $envelopeSender = $this->createMock(EnvelopeSender::class);
+        $envelopeSender->expects($this->never())->method('send');
+
+        $consumer = new SentryEventConsumer(
+            $envelopeSender,
+            $this->createStub(CircuitBreaker::class),
+            $helper
+        );
+        $consumer->process('');
+    }
+
+    public function testSuccessfulDeliveryRecordsSuccess(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isActive')->willReturn(true);
+
+        $envelopeSender = $this->createMock(EnvelopeSender::class);
+        $envelopeSender
+            ->expects($this->once())
+            ->method('send')
+            ->with('envelope-bytes');
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->expects($this->once())->method('recordSuccess');
+        $circuitBreaker->expects($this->never())->method('recordFailure');
+        $circuitBreaker->expects($this->never())->method('allowRequest');
+
+        $consumer = new SentryEventConsumer($envelopeSender, $circuitBreaker, $helper);
+        $consumer->process('envelope-bytes');
+    }
+
+    public function testFailureRecordsAndRethrows(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('isActive')->willReturn(true);
+
+        $exception = new RuntimeException('sentry 503');
+        $envelopeSender = $this->createStub(EnvelopeSender::class);
+        $envelopeSender->method('send')->willThrowException($exception);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->expects($this->once())->method('recordFailure');
+        $circuitBreaker->expects($this->never())->method('recordSuccess');
+
+        $this->expectExceptionObject($exception);
+
+        $consumer = new SentryEventConsumer($envelopeSender, $circuitBreaker, $helper);
+        $consumer->process('envelope-bytes');
+    }
+}

--- a/Test/Unit/Model/Queue/Publisher/SentryEventPublisherTest.php
+++ b/Test/Unit/Model/Queue/Publisher/SentryEventPublisherTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Test\Unit\Model\Queue\Publisher;
+
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
+use Magento\Framework\MessageQueue\PublisherInterface;
+use PHPUnit\Framework\TestCase;
+
+class SentryEventPublisherTest extends TestCase
+{
+    public function testPublishSendsPayloadOnTopic(): void
+    {
+        $payload = "{\"sent_at\":\"2026-01-01T00:00:00Z\"}\n{\"type\":\"event\"}";
+
+        $magentoPublisher = $this->createMock(PublisherInterface::class);
+        $magentoPublisher
+            ->expects($this->once())
+            ->method('publish')
+            ->with(SentryEventPublisher::TOPIC_NAME, $payload);
+
+        $publisher = new SentryEventPublisher($magentoPublisher);
+        $publisher->publish($payload);
+    }
+
+    public function testTopicNameIsStable(): void
+    {
+        $this->assertSame('justbetter.sentry.event.send', SentryEventPublisher::TOPIC_NAME);
+    }
+}

--- a/Test/Unit/Model/Transport/EnvelopeSenderTest.php
+++ b/Test/Unit/Model/Transport/EnvelopeSenderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Test\Unit\Model\Transport;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\Transport\EnvelopeSender;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class EnvelopeSenderTest extends TestCase
+{
+    public function testEmptyPayloadThrows(): void
+    {
+        $sender = new EnvelopeSender($this->createStub(Data::class));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Sentry envelope payload is empty.');
+
+        $sender->send('');
+    }
+
+    public function testMissingDsnThrows(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('getDSN')->willReturn(null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Sentry DSN is not configured.');
+
+        (new EnvelopeSender($helper))->send('not-empty');
+    }
+
+    public function testEmptyStringDsnThrows(): void
+    {
+        $helper = $this->createStub(Data::class);
+        $helper->method('getDSN')->willReturn('');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Sentry DSN is not configured.');
+
+        (new EnvelopeSender($helper))->send('not-empty');
+    }
+}

--- a/Test/Unit/Model/Transport/ResilientTransportTest.php
+++ b/Test/Unit/Model/Transport/ResilientTransportTest.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustBetter\Sentry\Test\Unit\Model\Transport;
+
+use JustBetter\Sentry\Helper\Data;
+use JustBetter\Sentry\Model\CircuitBreaker;
+use JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher;
+use JustBetter\Sentry\Model\Transport\ResilientTransport;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Sentry\Event;
+use Sentry\Serializer\PayloadSerializerInterface;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Sentry\Transport\TransportInterface;
+
+class ResilientTransportTest extends TestCase
+{
+    private function createTransport(
+        TransportInterface $httpTransport,
+        PayloadSerializerInterface $payloadSerializer,
+        SentryEventPublisher $publisher,
+        CircuitBreaker $circuitBreaker,
+        Data $helper
+    ): ResilientTransport {
+        return new ResilientTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $publisher,
+            $circuitBreaker,
+            $helper
+        );
+    }
+
+    public function testAsyncEnabledQueuesWithoutHttp(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(true);
+
+        $payloadSerializer = $this->createStub(PayloadSerializerInterface::class);
+        $payloadSerializer->method('serialize')->willReturn("envelope\nbody");
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish')->with("envelope\nbody");
+
+        $httpTransport = $this->createMock(TransportInterface::class);
+        $httpTransport->expects($this->never())->method('send');
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->expects($this->never())->method('allowRequest');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+        $this->assertSame($event, $result->getEvent());
+    }
+
+    public function testSyncSuccessRecordsCircuitSuccess(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(true);
+        $circuitBreaker->expects($this->once())->method('recordSuccess');
+        $circuitBreaker->expects($this->never())->method('recordFailure');
+
+        $httpTransport = $this->createMock(TransportInterface::class);
+        $httpTransport
+            ->expects($this->once())
+            ->method('send')
+            ->with($event)
+            ->willReturn(new Result(ResultStatus::success(), $event));
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $this->createStub(PayloadSerializerInterface::class),
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+
+    public function testSyncHttpExceptionFallsBackToQueueWhenEnabled(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $helper->method('isAsyncFallbackOnCircuitOpen')->willReturn(true);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(true);
+        $circuitBreaker->expects($this->once())->method('recordFailure');
+
+        $httpTransport = $this->createStub(TransportInterface::class);
+        $httpTransport->method('send')->willThrowException(new RuntimeException('network down'));
+
+        $payloadSerializer = $this->createStub(PayloadSerializerInterface::class);
+        $payloadSerializer->method('serialize')->willReturn('payload');
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish')->with('payload');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+
+    public function testSyncHttpExceptionFailsWhenFallbackDisabled(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $helper->method('isAsyncFallbackOnCircuitOpen')->willReturn(false);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(true);
+        $circuitBreaker->expects($this->once())->method('recordFailure');
+
+        $httpTransport = $this->createStub(TransportInterface::class);
+        $httpTransport->method('send')->willThrowException(new RuntimeException('network down'));
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $this->createStub(PayloadSerializerInterface::class),
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::failed(), (string) $result->getStatus());
+    }
+
+    public function testServerSideFailureRecordsAndFallsBack(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $helper->method('isAsyncFallbackOnCircuitOpen')->willReturn(true);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(true);
+        $circuitBreaker->expects($this->once())->method('recordFailure');
+
+        $httpTransport = $this->createStub(TransportInterface::class);
+        $httpTransport->method('send')->willReturn(new Result(ResultStatus::failed(), $event));
+
+        $payloadSerializer = $this->createStub(PayloadSerializerInterface::class);
+        $payloadSerializer->method('serialize')->willReturn('payload');
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish')->with('payload');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+
+    public function testInvalidResultDoesNotTripCircuitOrQueue(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+
+        $circuitBreaker = $this->createMock(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(true);
+        $circuitBreaker->expects($this->never())->method('recordFailure');
+        $circuitBreaker->expects($this->never())->method('recordSuccess');
+
+        $httpTransport = $this->createStub(TransportInterface::class);
+        $httpTransport->method('send')->willReturn(new Result(ResultStatus::invalid(), $event));
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $this->createStub(PayloadSerializerInterface::class),
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::invalid(), (string) $result->getStatus());
+    }
+
+    public function testOpenCircuitQueuesWhenFallbackEnabled(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $helper->method('isAsyncFallbackOnCircuitOpen')->willReturn(true);
+
+        $circuitBreaker = $this->createStub(CircuitBreaker::class);
+        $circuitBreaker->method('allowRequest')->willReturn(false);
+
+        $payloadSerializer = $this->createStub(PayloadSerializerInterface::class);
+        $payloadSerializer->method('serialize')->willReturn('queued');
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish')->with('queued');
+
+        $httpTransport = $this->createMock(TransportInterface::class);
+        $httpTransport->expects($this->never())->method('send');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $payloadSerializer,
+            $publisher,
+            $circuitBreaker,
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+
+    public function testOpenCircuitWithoutFallbackGoesHttp(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(false);
+        $helper->method('isCircuitBreakerEnabled')->willReturn(true);
+        $helper->method('isAsyncFallbackOnCircuitOpen')->willReturn(false);
+
+        $httpTransport = $this->createMock(TransportInterface::class);
+        $httpTransport
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(new Result(ResultStatus::success(), $event));
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->never())->method('publish');
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $this->createStub(PayloadSerializerInterface::class),
+            $publisher,
+            $this->createStub(CircuitBreaker::class),
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+
+    public function testQueueSetsTimestampWhenMissing(): void
+    {
+        $event = Event::createEvent();
+        $event->setTimestamp(null);
+
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(true);
+
+        $before = microtime(true);
+        $capturedTimestamp = null;
+
+        $payloadSerializer = $this->createMock(PayloadSerializerInterface::class);
+        $payloadSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($this->callback(static function (Event $event) use (&$capturedTimestamp): bool {
+                $capturedTimestamp = $event->getTimestamp();
+
+                return true;
+            }))
+            ->willReturn('payload');
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish');
+
+        $this->createTransport(
+            $this->createStub(TransportInterface::class),
+            $payloadSerializer,
+            $publisher,
+            $this->createStub(CircuitBreaker::class),
+            $helper
+        )->send($event);
+
+        $after = microtime(true);
+
+        $this->assertIsFloat($capturedTimestamp);
+        $this->assertGreaterThanOrEqual($before, $capturedTimestamp);
+        $this->assertLessThanOrEqual($after, $capturedTimestamp);
+        $this->assertSame($capturedTimestamp, $event->getTimestamp());
+    }
+
+    public function testQueuePreservesExistingTimestamp(): void
+    {
+        $existingTimestamp = 1_700_000_000.123456;
+        $event = Event::createEvent();
+        $event->setTimestamp($existingTimestamp);
+
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(true);
+
+        $payloadSerializer = $this->createMock(PayloadSerializerInterface::class);
+        $payloadSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($this->callback(static function (Event $event) use ($existingTimestamp): bool {
+                return $event->getTimestamp() === $existingTimestamp;
+            }))
+            ->willReturn('payload');
+
+        $publisher = $this->createMock(SentryEventPublisher::class);
+        $publisher->expects($this->once())->method('publish');
+
+        $this->createTransport(
+            $this->createStub(TransportInterface::class),
+            $payloadSerializer,
+            $publisher,
+            $this->createStub(CircuitBreaker::class),
+            $helper
+        )->send($event);
+
+        $this->assertSame($existingTimestamp, $event->getTimestamp());
+    }
+
+    public function testPublishExceptionReturnsFailed(): void
+    {
+        $event = Event::createEvent();
+        $helper = $this->createStub(Data::class);
+        $helper->method('isAsyncSendingEnabled')->willReturn(true);
+
+        $payloadSerializer = $this->createStub(PayloadSerializerInterface::class);
+        $payloadSerializer->method('serialize')->willReturn('payload');
+
+        $publisher = $this->createStub(SentryEventPublisher::class);
+        $publisher->method('publish')->willThrowException(new RuntimeException('mq down'));
+
+        $result = $this->createTransport(
+            $this->createStub(TransportInterface::class),
+            $payloadSerializer,
+            $publisher,
+            $this->createStub(CircuitBreaker::class),
+            $helper
+        )->send($event);
+
+        $this->assertSame((string) ResultStatus::failed(), (string) $result->getStatus());
+    }
+
+    public function testCloseDelegatesToHttpTransport(): void
+    {
+        $httpTransport = $this->createMock(TransportInterface::class);
+        $httpTransport
+            ->expects($this->once())
+            ->method('close')
+            ->with(5)
+            ->willReturn(new Result(ResultStatus::success()));
+
+        $result = $this->createTransport(
+            $httpTransport,
+            $this->createStub(PayloadSerializerInterface::class),
+            $this->createStub(SentryEventPublisher::class),
+            $this->createStub(CircuitBreaker::class),
+            $this->createStub(Data::class)
+        )->close(5);
+
+        $this->assertSame((string) ResultStatus::success(), (string) $result->getStatus());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
     "magento/module-csp": "*",
     "nyholm/psr7": "^1.2",
     "magento/module-config": ">=101.2",
+    "magento/framework-message-queue": "*",
+    "magento/module-message-queue": "*",
     "justbetter/magento2-core": "^1.0"
   },
   "repositories": {
@@ -66,7 +68,8 @@
     "allow-plugins": {
       "php-http/discovery": true,
       "magento/composer-dependency-version-audit-plugin": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "magento/magento-composer-installer": true
     }
   },
   "scripts": {
@@ -83,6 +86,8 @@
     "bitexpert/phpstan-magento": "^0.42.0",
     "magento/magento-coding-standard": ">=40",
     "rector/rector": ">=1.2.5",
-    "justbetter/magento2-coding-standard": "^1.0,>=1.0.2"
+    "justbetter/magento2-coding-standard": "^1.0,>=1.0.2",
+    "phpcompatibility/php-compatibility": "*",
+    "phpunit/phpunit": "*"
   }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -146,6 +146,70 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="async_sending_enabled" translate="label comment" type="select" sortOrder="100" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Async Sending (Message Queue)</label>
+                    <comment><![CDATA[When enabled, Sentry envelopes are published to Magento MQ on the request path and delivered by the <code>justbetter.sentry.event</code> consumer. Envelope timestamps are frozen at publish time.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="async_fallback_on_circuit_open" translate="label comment" type="select" sortOrder="110" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Queue When Circuit Open / Sync Fails</label>
+                    <comment><![CDATA[If synchronous delivery fails or the circuit breaker is open, fall back to async MQ publishing.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="circuit_breaker_enabled" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Circuit Breaker Enabled</label>
+                    <comment><![CDATA[Fail fast on synchronous Sentry HTTP calls after repeated failures so a degraded Sentry does not stall shoppers.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="circuit_breaker_failure_threshold" translate="label" type="text" sortOrder="130" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Circuit Breaker Failure Threshold</label>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                        <field id="circuit_breaker_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="circuit_breaker_recovery_timeout" translate="label comment" type="text" sortOrder="140" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Circuit Breaker Recovery Timeout (seconds)</label>
+                    <comment><![CDATA[How long the circuit stays open before a probe request is allowed.]]></comment>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                        <field id="circuit_breaker_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="circuit_breaker_success_threshold" translate="label" type="text" sortOrder="150" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Circuit Breaker Success Threshold</label>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                        <field id="circuit_breaker_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="http_timeout" translate="label comment" type="text" sortOrder="160" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Sentry HTTP Timeout (seconds)</label>
+                    <comment><![CDATA[Total HTTP timeout for synchronous and consumer envelope delivery. Keep low on the storefront.]]></comment>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
+                <field id="http_connect_timeout" translate="label" type="text" sortOrder="170" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
+                    <label>Sentry HTTP Connect Timeout (seconds)</label>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="issue_grouping" translate="label" type="text" sortOrder="30" showInDefault="1" showInStore="0" showInWebsite="0" canRestore="1">
                 <label>Sentry issue grouping</label>

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="justbetter.sentry.event.send" request="string">
+        <handler name="justbetterSentryEventSend"
+                 type="JustBetter\Sentry\Model\Queue\Consumer\SentryEventConsumer"
+                 method="process"/>
+    </topic>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,6 +26,14 @@
                 <tracing_enabled/>
                 <tracing_sample_data/>
                 <ignore_js_errors/>
+                <async_sending_enabled>0</async_sending_enabled>
+                <async_fallback_on_circuit_open>1</async_fallback_on_circuit_open>
+                <circuit_breaker_enabled>1</circuit_breaker_enabled>
+                <circuit_breaker_failure_threshold>5</circuit_breaker_failure_threshold>
+                <circuit_breaker_recovery_timeout>60</circuit_breaker_recovery_timeout>
+                <circuit_breaker_success_threshold>2</circuit_breaker_success_threshold>
+                <http_timeout>2</http_timeout>
+                <http_connect_timeout>1</http_connect_timeout>
             </environment>
         </sentry>
     </default>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -90,4 +90,27 @@
     <type name="Magento\Cron\Model\Schedule">
         <plugin name="sentry-cron-checkin" type="JustBetter\Sentry\Plugin\CronScheduleCheckIn" disabled="false"/>
     </type>
+
+    <!-- Resilient async delivery -->
+    <type name="JustBetter\Sentry\Model\SentryInteraction">
+        <arguments>
+            <argument name="resilientTransportFactory" xsi:type="object">JustBetter\Sentry\Model\Transport\ResilientTransportFactory\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="JustBetter\Sentry\Model\Transport\ResilientTransportFactory">
+        <arguments>
+            <argument name="publisher" xsi:type="object">JustBetter\Sentry\Model\Queue\Publisher\SentryEventPublisher\Proxy</argument>
+            <argument name="circuitBreaker" xsi:type="object">JustBetter\Sentry\Model\CircuitBreaker\Proxy</argument>
+            <argument name="helper" xsi:type="object">JustBetter\Sentry\Helper\Data\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="JustBetter\Sentry\Model\Queue\Consumer\SentryEventConsumer">
+        <arguments>
+            <argument name="envelopeSender" xsi:type="object">JustBetter\Sentry\Model\Transport\EnvelopeSender\Proxy</argument>
+            <argument name="circuitBreaker" xsi:type="object">JustBetter\Sentry\Model\CircuitBreaker\Proxy</argument>
+            <argument name="helper" xsi:type="object">JustBetter\Sentry\Helper\Data\Proxy</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="JustBetter_Sentry" setup_version="2.0.0">
         <sequence>
             <module name="Magento_Store"/>
+            <module name="Magento_MessageQueue"/>
             <module name="JustBetter_Core"/>
         </sequence>
     </module>

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+    <consumer name="justbetter.sentry.event"
+              queue="justbetter.sentry.event"
+              handler="JustBetter\Sentry\Model\Queue\Consumer\SentryEventConsumer::process"
+              consumerInstance="Magento\Framework\MessageQueue\Consumer"
+              maxMessages="500"/>
+</config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
+    <publisher topic="justbetter.sentry.event.send"/>
+</config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+    <exchange name="magento" type="topic">
+        <binding id="JustBetterSentryEventSend"
+                 topic="justbetter.sentry.event.send"
+                 destinationType="queue"
+                 destination="justbetter.sentry.event"/>
+    </exchange>
+</config>


### PR DESCRIPTION
**Summary**
There is a major drawback in the PHP implementation: communication with Sentry interferes with shoppers' critical paths.
Consequently, if Sentry goes down (that is a case especially with self-hosted Sentry), the whole website will experience the issue.
We experienced the issue on production, where the current implementation caused 5-15s of extra loading time on all storefront pages.

**Related issue**
https://github.com/justbetter/magento2-sentry/issues/246

**Result**
This pull request adds several features to improve the resilience of the extension:
- async message processing (via Magento's MQs) - a new topology with its own consumer
- Circuit breaker on async paths - temporarily shut down communication with Sentry (or redirect it into the async path) if the service becomes unavailable
- http/connection timeout settings

**Checklist**

- [x] I've ran `composer run codestyle`
- [x] I've ran `composer run analyse`